### PR TITLE
Feature/server core turn state model

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/ClientCommand.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/ClientCommand.java
@@ -1,0 +1,15 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClientCommand {
+    private CommandType type;
+    private String lobbyId;
+    private String playerId;
+    private Integer moveSteps;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
@@ -1,0 +1,9 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+public enum CommandType {
+    JOIN_LOBBY,
+    START_GAME,
+    ROLL_DICE,
+    MOVE_TOKEN,
+    LEAVE_LOBBY
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GamePhase.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GamePhase.java
@@ -1,0 +1,7 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+public enum GamePhase {
+    LOBBY,
+    CITY_ASSIGNMENT,
+    IN_TURN
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameRoomState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameRoomState.java
@@ -1,0 +1,20 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameRoomState {
+    private String lobbyId;
+    private List<PlayerState> players = new ArrayList<>();
+    private GamePhase phase = GamePhase.LOBBY;
+    private String currentPlayerId;
+    private Integer lastDiceValue;
+    private long version = 0L;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/PlayerState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/PlayerState.java
@@ -1,0 +1,14 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlayerState {
+    private String playerId;
+    private String assignedCity;
+    private int boardPosition;
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
@@ -1,0 +1,87 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TurnBasedDtosUnitTest {
+
+    @Test
+    void commandTypeContainsExpectedValues() {
+        assertThat(CommandType.values()).containsExactly(
+                CommandType.JOIN_LOBBY,
+                CommandType.START_GAME,
+                CommandType.ROLL_DICE,
+                CommandType.MOVE_TOKEN,
+                CommandType.LEAVE_LOBBY
+        );
+    }
+
+    @Test
+    void gamePhaseContainsExpectedValues() {
+        assertThat(GamePhase.values()).containsExactly(
+                GamePhase.LOBBY,
+                GamePhase.CITY_ASSIGNMENT,
+                GamePhase.IN_TURN
+        );
+    }
+
+    @Test
+    void clientCommandStoresProvidedValues() {
+        ClientCommand command = new ClientCommand(
+                CommandType.MOVE_TOKEN,
+                "lobby-1",
+                "player-1",
+                4
+        );
+
+        assertThat(command.getType()).isEqualTo(CommandType.MOVE_TOKEN);
+        assertThat(command.getLobbyId()).isEqualTo("lobby-1");
+        assertThat(command.getPlayerId()).isEqualTo("player-1");
+        assertThat(command.getMoveSteps()).isEqualTo(4);
+    }
+
+    @Test
+    void playerStateStoresProvidedValues() {
+        PlayerState playerState = new PlayerState("player-1", "Vienna", 12);
+
+        assertThat(playerState.getPlayerId()).isEqualTo("player-1");
+        assertThat(playerState.getAssignedCity()).isEqualTo("Vienna");
+        assertThat(playerState.getBoardPosition()).isEqualTo(12);
+    }
+
+    @Test
+    void gameRoomStateStoresProvidedValues() {
+        List<PlayerState> players = new ArrayList<>();
+        players.add(new PlayerState("player-1", "Vienna", 2));
+
+        GameRoomState roomState = new GameRoomState(
+                "lobby-1",
+                players,
+                GamePhase.IN_TURN,
+                "player-1",
+                6,
+                3L
+        );
+
+        assertThat(roomState.getLobbyId()).isEqualTo("lobby-1");
+        assertThat(roomState.getPlayers()).hasSize(1);
+        assertThat(roomState.getPhase()).isEqualTo(GamePhase.IN_TURN);
+        assertThat(roomState.getCurrentPlayerId()).isEqualTo("player-1");
+        assertThat(roomState.getLastDiceValue()).isEqualTo(6);
+        assertThat(roomState.getVersion()).isEqualTo(3L);
+    }
+
+    @Test
+    void gameRoomStateDefaultValuesMatchTurnSetupNeeds() {
+        GameRoomState roomState = new GameRoomState();
+
+        assertThat(roomState.getPlayers()).isNotNull();
+        assertThat(roomState.getPlayers()).isEmpty();
+        assertThat(roomState.getPhase()).isEqualTo(GamePhase.LOBBY);
+        assertThat(roomState.getVersion()).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
**Summary**
- Introduce core DTO and enum contracts for turn-based multiplayer state in `Weltreise_Server`.
- Add `GameRoomState`, `PlayerState`, `GamePhase`, `CommandType`, and `ClientCommand` as server-side foundations.
- Add unit tests to cover new DTO defaults and enum/value mappings for SonarCloud quality gates.
**Why**
This PR establishes explicit server-side contracts for the upcoming
authoritative turn flow (`join -> start -> roll -> move -> next`).
Having stable in-memory state models first reduces risk for the next
implementation steps and keeps future command validation predictable.
Closes #3 , #4 , #5 