### PR TITLE
Enforce turn order for dice and movement

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -1,0 +1,121 @@
+package at.aau.serg.websocketdemoserver.game;
+
+import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import at.aau.serg.websocketdemoserver.messaging.dtos.PlayerState;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+@Service
+public class GameCommandService {
+    private final Random random;
+
+    public GameCommandService() {
+        this(new Random());
+    }
+
+    public GameCommandService(Random random) {
+        this.random = Objects.requireNonNull(random, "random must not be null");
+    }
+
+    public void processCommand(GameRoomState state, ClientCommand command) {
+        validateBase(state, command);
+        if (command.getType() == CommandType.ROLL_DICE) {
+            handleRollDice(state, command);
+            return;
+        }
+
+        if (command.getType() == CommandType.MOVE_TOKEN) {
+            handleMoveToken(state, command);
+            return;
+        }
+
+        throw new IllegalArgumentException("Unsupported command type for turn flow");
+    }
+
+    private void handleRollDice(GameRoomState state, ClientCommand command) {
+        validateTurnContext(state, command);
+        if (state.getLastDiceValue() != null) {
+            throw new IllegalArgumentException("Dice already rolled for current turn");
+        }
+
+        state.setLastDiceValue(random.nextInt(6) + 1);
+        state.setVersion(state.getVersion() + 1);
+    }
+
+    private void handleMoveToken(GameRoomState state, ClientCommand command) {
+        validateTurnContext(state, command);
+        Integer moveSteps = command.getMoveSteps();
+
+        if (state.getLastDiceValue() == null) {
+            throw new IllegalArgumentException("Roll dice before moving");
+        }
+        if (moveSteps == null) {
+            throw new IllegalArgumentException("Move steps are required");
+        }
+        if (!state.getLastDiceValue().equals(moveSteps)) {
+            throw new IllegalArgumentException("Move steps must match dice value");
+        }
+
+        PlayerState playerState = findPlayerState(state.getPlayers(), command.getPlayerId());
+        playerState.setBoardPosition(playerState.getBoardPosition() + moveSteps);
+
+        String nextPlayerId = nextPlayerId(state.getPlayers(), state.getCurrentPlayerId());
+        state.setCurrentPlayerId(nextPlayerId);
+        state.setLastDiceValue(null);
+        state.setVersion(state.getVersion() + 1);
+    }
+
+    private void validateBase(GameRoomState state, ClientCommand command) {
+        if (state == null || command == null) {
+            throw new IllegalArgumentException("State and command are required");
+        }
+        if (command.getType() == null || command.getPlayerId() == null) {
+            throw new IllegalArgumentException("Command type and playerId are required");
+        }
+    }
+
+    private void validateTurnContext(GameRoomState state, ClientCommand command) {
+        if (state.getPhase() != GamePhase.IN_TURN) {
+            throw new IllegalArgumentException("Command not allowed in current phase");
+        }
+        if (state.getCurrentPlayerId() == null) {
+            throw new IllegalArgumentException("Current player is not set");
+        }
+        if (!state.getCurrentPlayerId().equals(command.getPlayerId())) {
+            throw new IllegalArgumentException("Not your turn");
+        }
+    }
+
+    private PlayerState findPlayerState(List<PlayerState> players, String playerId) {
+        return players.stream()
+                .filter(player -> playerId.equals(player.getPlayerId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Player is not in lobby"));
+    }
+
+    private String nextPlayerId(List<PlayerState> players, String currentPlayerId) {
+        if (players == null || players.isEmpty()) {
+            throw new IllegalArgumentException("At least one player is required");
+        }
+
+        int currentIndex = -1;
+        for (int i = 0; i < players.size(); i++) {
+            if (currentPlayerId.equals(players.get(i).getPlayerId())) {
+                currentIndex = i;
+                break;
+            }
+        }
+        if (currentIndex < 0) {
+            throw new IllegalArgumentException("Current player is not in lobby");
+        }
+
+        int nextIndex = (currentIndex + 1) % players.size();
+        return players.get(nextIndex).getPlayerId();
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
@@ -1,0 +1,123 @@
+package at.aau.serg.websocketdemoserver.game;
+
+import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import at.aau.serg.websocketdemoserver.messaging.dtos.PlayerState;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GameCommandServiceUnitTest {
+
+    @Test
+    void rollDiceSetsDiceValueAndIncrementsVersion() {
+        GameCommandService service = new GameCommandService(new FixedRandom(4));
+        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+
+        service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null));
+
+        assertThat(state.getLastDiceValue()).isEqualTo(5);
+        assertThat(state.getVersion()).isEqualTo(1L);
+    }
+
+    @Test
+    void rollDiceRejectsNonActivePlayer() {
+        GameCommandService service = new GameCommandService(new FixedRandom(1));
+        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+
+        assertThatThrownBy(() -> service.processCommand(
+                state,
+                new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-2", null)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not your turn");
+    }
+
+    @Test
+    void moveTokenRejectsWhenDiceWasNotRolled() {
+        GameCommandService service = new GameCommandService(new FixedRandom(1));
+        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+
+        assertThatThrownBy(() -> service.processCommand(
+                state,
+                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 3)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Roll dice before moving");
+    }
+
+    @Test
+    void moveTokenRejectsWhenStepsDoNotMatchDiceValue() {
+        GameCommandService service = new GameCommandService(new FixedRandom(3));
+        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null));
+
+        assertThatThrownBy(() -> service.processCommand(
+                state,
+                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 2)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Move steps must match dice value");
+    }
+
+    @Test
+    void moveTokenAdvancesPositionRotatesTurnAndClearsDice() {
+        GameCommandService service = new GameCommandService(new FixedRandom(2));
+        List<PlayerState> players = players("player-1", "player-2");
+        GameRoomState state = inTurnState("player-1", players);
+        service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null));
+
+        service.processCommand(state, new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 3));
+
+        assertThat(players.get(0).getBoardPosition()).isEqualTo(3);
+        assertThat(state.getCurrentPlayerId()).isEqualTo("player-2");
+        assertThat(state.getLastDiceValue()).isNull();
+        assertThat(state.getVersion()).isEqualTo(2L);
+    }
+
+    @Test
+    void moveTokenRejectsNonActivePlayer() {
+        GameCommandService service = new GameCommandService(new FixedRandom(1));
+        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null));
+
+        assertThatThrownBy(() -> service.processCommand(
+                state,
+                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-2", 2)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not your turn");
+    }
+
+    private GameRoomState inTurnState(String currentPlayerId, List<PlayerState> players) {
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+        state.setPlayers(players);
+        state.setPhase(GamePhase.IN_TURN);
+        state.setCurrentPlayerId(currentPlayerId);
+        return state;
+    }
+
+    private List<PlayerState> players(String firstPlayerId, String secondPlayerId) {
+        List<PlayerState> players = new ArrayList<>();
+        players.add(new PlayerState(firstPlayerId, "Vienna", 0));
+        players.add(new PlayerState(secondPlayerId, "Paris", 0));
+        return players;
+    }
+
+    private static class FixedRandom extends Random {
+        private final int value;
+
+        private FixedRandom(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int nextInt(int bound) {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
**Summary**
- Add `GameCommandService` to enforce server-authoritative turn rules.
- Validate that only the active player can execute `ROLL_DICE` and `MOVE_TOKEN`.
- Enforce movement consistency by requiring `moveSteps == lastDiceValue`.
- Rotate to the next player after a valid move and clear per-turn dice state.
- Add unit tests for positive and negative turn-order scenarios.
**Why**
Turn sequencing must be validated on the server to avoid client-side
desync and illegal actions in multiplayer sessions.
This change introduces deterministic command handling for the core
turn loop and provides regression-safe tests for the most critical
rule checks.
**Completed Issues**
Closes #9 
Closes #10 