### PR TITLE
Route lobby commands through websocket endpoint

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandResponse.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandResponse.java
@@ -1,0 +1,14 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommandResponse {
+    private boolean success;
+    private String message;
+    private String lobbyId;
+    private CommandType commandType;
+    private GameRoomState state;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -1,6 +1,14 @@
 package at.aau.serg.websocketdemoserver.websocket.broker;
 
+import at.aau.serg.websocketdemoserver.game.GameCommandService;
+import at.aau.serg.websocketdemoserver.game.InMemoryLobbyStore;
+import at.aau.serg.websocketdemoserver.game.LobbyService;
+import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandResponse;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
 import at.aau.serg.websocketdemoserver.messaging.dtos.StompMessage;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 
@@ -9,6 +17,18 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 public class WebSocketBrokerController {
+    private final LobbyService lobbyService;
+    private final GameCommandService gameCommandService;
+    private final InMemoryLobbyStore lobbyStore;
+
+    public WebSocketBrokerController(LobbyService lobbyService,
+                                     GameCommandService gameCommandService,
+                                     InMemoryLobbyStore lobbyStore) {
+        this.lobbyService = lobbyService;
+        this.gameCommandService = gameCommandService;
+        this.lobbyStore = lobbyStore;
+    }
+
     @MessageMapping("/hello")
     @SendTo("/topic/hello-response")
     public String handleHello(String text) {
@@ -20,6 +40,34 @@ public class WebSocketBrokerController {
     public StompMessage handleObject(StompMessage msg) {
 
        return msg;
+    }
+
+    @MessageMapping("/lobby/{lobbyId}/command")
+    @SendTo("/topic/lobby/{lobbyId}/events")
+    public CommandResponse handleLobbyCommand(@DestinationVariable String lobbyId, ClientCommand command) {
+        CommandType commandType = command != null ? command.getType() : null;
+        try {
+            if (command == null || commandType == null) {
+                throw new IllegalArgumentException("Command type is required");
+            }
+            command.setLobbyId(lobbyId);
+
+            GameRoomState state = switch (commandType) {
+                case JOIN_LOBBY -> lobbyService.joinLobby(lobbyId, command.getPlayerId());
+                case LEAVE_LOBBY -> lobbyService.leaveLobby(lobbyId, command.getPlayerId());
+                case START_GAME -> lobbyService.startGame(lobbyId);
+                case ROLL_DICE, MOVE_TOKEN -> {
+                    GameRoomState existingState = lobbyStore.get(lobbyId)
+                            .orElseThrow(() -> new IllegalArgumentException("Lobby not found"));
+                    gameCommandService.processCommand(existingState, command);
+                    yield existingState;
+                }
+            };
+
+            return new CommandResponse(true, "OK", lobbyId, commandType, state);
+        } catch (IllegalArgumentException ex) {
+            return new CommandResponse(false, ex.getMessage(), lobbyId, commandType, null);
+        }
     }
 
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerUnitTest.java
@@ -1,0 +1,91 @@
+package at.aau.serg.websocketdemoserver.websocket.broker;
+
+import at.aau.serg.websocketdemoserver.game.GameCommandService;
+import at.aau.serg.websocketdemoserver.game.InMemoryLobbyStore;
+import at.aau.serg.websocketdemoserver.game.LobbyService;
+import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandResponse;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketBrokerControllerUnitTest {
+
+    @Mock
+    private LobbyService lobbyService;
+    @Mock
+    private GameCommandService gameCommandService;
+    @Mock
+    private InMemoryLobbyStore lobbyStore;
+
+    @Test
+    void handleLobbyCommandRoutesJoinAndReturnsSuccessResponse() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(CommandType.JOIN_LOBBY, null, "player-1", null);
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+
+        when(lobbyService.joinLobby("lobby-1", "player-1")).thenReturn(state);
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getLobbyId()).isEqualTo("lobby-1");
+        assertThat(response.getCommandType()).isEqualTo(CommandType.JOIN_LOBBY);
+        assertThat(response.getState()).isEqualTo(state);
+        verify(lobbyService).joinLobby("lobby-1", "player-1");
+    }
+
+    @Test
+    void handleLobbyCommandRoutesRollDiceThroughGameService() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(CommandType.ROLL_DICE, null, "player-1", null);
+        GameRoomState state = new GameRoomState();
+        when(lobbyStore.get("lobby-1")).thenReturn(Optional.of(state));
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getCommandType()).isEqualTo(CommandType.ROLL_DICE);
+        assertThat(response.getState()).isEqualTo(state);
+        verify(gameCommandService).processCommand(state, command);
+    }
+
+    @Test
+    void handleLobbyCommandReturnsErrorResponseOnValidationFailure() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(CommandType.START_GAME, null, "player-1", null);
+        doThrow(new IllegalArgumentException("At least two players are required"))
+                .when(lobbyService).startGame("lobby-1");
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).contains("At least two players");
+        assertThat(response.getCommandType()).isEqualTo(CommandType.START_GAME);
+        assertThat(response.getState()).isNull();
+    }
+
+    @Test
+    void handleLobbyCommandReturnsErrorWhenCommandTypeIsMissing() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(null, null, "player-1", null);
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).contains("Command type is required");
+        assertThat(response.getCommandType()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Add a new websocket command endpoint: `/app/lobby/{lobbyId}/command`.
- Route `JOIN_LOBBY`, `LEAVE_LOBBY`, `START_GAME`, `ROLL_DICE`, and `MOVE_TOKEN` to existing server services.
- Introduce `CommandResponse` to return structured success/error payloads.
- Keep lobby event publishing on `/topic/lobby/{lobbyId}/events`.
- Add unit tests for command routing and validation error paths.
## Completed issues
- Closes #7 
- Refs #11 
## Why
The server now needs a single command ingress point so multiplayer
clients can use one consistent flow for lobby and turn actions.
This PR connects the endpoint to current services and returns stable
response envelopes, preparing the groundwork for standardized error
codes and full integration test coverage.
