### PR TITLE
Add CREATE_LOBBY command and validate game PIN

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/game/InMemoryLobbyStore.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/InMemoryLobbyStore.java
@@ -23,6 +23,11 @@ public class InMemoryLobbyStore {
         });
     }
 
+    public void put(String lobbyId, GameRoomState state) {
+        validateLobbyId(lobbyId);
+        lobbies.put(lobbyId, state);
+    }
+
     public Optional<GameRoomState> get(String lobbyId) {
         validateLobbyId(lobbyId);
         return Optional.ofNullable(lobbies.get(lobbyId));

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/LobbyService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/LobbyService.java
@@ -27,9 +27,22 @@ public class LobbyService {
         this.cityDistributor = Objects.requireNonNull(cityDistributor, "cityDistributor must not be null");
     }
 
+    public GameRoomState createLobby(String lobbyId, String playerId) {
+        if (lobbyStore.get(lobbyId).isPresent()) {
+            throw new IllegalArgumentException("Lobby already exists");
+        }
+        GameRoomState newLobby = new GameRoomState();
+        newLobby.setLobbyId(lobbyId);
+        newLobby.getPlayers().add(new PlayerState(playerId));
+        lobbyStore.put(lobbyId, newLobby);
+        return newLobby;
+    }
+
     public GameRoomState joinLobby(String lobbyId, String playerId) {
         validatePlayerId(playerId);
-        GameRoomState state = lobbyStore.getOrCreate(lobbyId);
+        GameRoomState state = lobbyStore.get(lobbyId).orElseThrow(() -> 
+            new IllegalArgumentException("Lobby does not exist. Please check the Game PIN!")
+        );
 
         if (state.getPhase() != GamePhase.LOBBY) {
             throw new IllegalArgumentException("Cannot join started game");

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
@@ -4,6 +4,7 @@ package at.aau.serg.websocketdemoserver.messaging.dtos;
  * Enum für die Typen an Kommandos, die ein Client an den Server schicken kann.
  */
 public enum CommandType {
+    CREATE_LOBBY,
     JOIN_LOBBY,
     START_GAME,
     ROLL_DICE,

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -57,6 +57,7 @@ public class WebSocketBrokerController {
             command.setLobbyId(lobbyId);
 
             GameRoomState state = switch (commandType) {
+                case CREATE_LOBBY -> lobbyService.createLobby(lobbyId, command.getPlayerId());
                 case JOIN_LOBBY -> lobbyService.joinLobby(lobbyId, command.getPlayerId());
                 case LEAVE_LOBBY -> lobbyService.leaveLobby(lobbyId, command.getPlayerId());
                 case START_GAME -> lobbyService.startGame(lobbyId);

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
@@ -37,8 +37,8 @@ class GameCommandServiceUnitTest {
 
         assertThatThrownBy(() -> service.processCommand(
                 state,
-                new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-2", null)
-        )).isInstanceOf(IllegalArgumentException.class)
+                new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-2", null)))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Not your turn");
     }
 
@@ -49,8 +49,8 @@ class GameCommandServiceUnitTest {
 
         assertThatThrownBy(() -> service.processCommand(
                 state,
-                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 3)
-        )).isInstanceOf(IllegalArgumentException.class)
+                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 3)))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Roll dice before moving");
     }
 
@@ -62,8 +62,8 @@ class GameCommandServiceUnitTest {
 
         assertThatThrownBy(() -> service.processCommand(
                 state,
-                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 2)
-        )).isInstanceOf(IllegalArgumentException.class)
+                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 2)))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Move steps must match dice value");
     }
 
@@ -90,8 +90,8 @@ class GameCommandServiceUnitTest {
 
         assertThatThrownBy(() -> service.processCommand(
                 state,
-                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-2", 2)
-        )).isInstanceOf(IllegalArgumentException.class)
+                new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-2", 2)))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Not your turn");
     }
 

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/InMemoryLobbyStoreUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/InMemoryLobbyStoreUnitTest.java
@@ -1,0 +1,136 @@
+package at.aau.serg.websocketdemoserver.game;
+
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InMemoryLobbyStoreUnitTest {
+
+    private InMemoryLobbyStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryLobbyStore();
+    }
+
+    // ========== PUT TESTS ==========
+
+    @Test
+    void putStoresLobbyState() {
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+
+        store.put("lobby-1", state);
+
+        assertThat(store.get("lobby-1")).isPresent();
+        assertThat(store.get("lobby-1").get().getLobbyId()).isEqualTo("lobby-1");
+    }
+
+    @Test
+    void putOverwritesExistingLobby() {
+        GameRoomState state1 = new GameRoomState();
+        state1.setLobbyId("lobby-1");
+        state1.setVersion(1L);
+
+        GameRoomState state2 = new GameRoomState();
+        state2.setLobbyId("lobby-1");
+        state2.setVersion(2L);
+
+        store.put("lobby-1", state1);
+        store.put("lobby-1", state2);
+
+        assertThat(store.get("lobby-1").get().getVersion()).isEqualTo(2L);
+    }
+
+    @Test
+    void putRejectsNullLobbyId() {
+        GameRoomState state = new GameRoomState();
+
+        assertThatThrownBy(() -> store.put(null, state))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Lobby id is required");
+    }
+
+    @Test
+    void putRejectsBlankLobbyId() {
+        GameRoomState state = new GameRoomState();
+
+        assertThatThrownBy(() -> store.put("   ", state))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Lobby id is required");
+    }
+
+    // ========== GET TESTS ==========
+
+    @Test
+    void getReturnsEmptyForNonExistentLobby() {
+        assertThat(store.get("non-existent")).isEmpty();
+    }
+
+    @Test
+    void getReturnsLobbyWhenExists() {
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+        store.put("lobby-1", state);
+
+        assertThat(store.get("lobby-1")).isPresent();
+    }
+
+    @Test
+    void getRejectsNullLobbyId() {
+        assertThatThrownBy(() -> store.get(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Lobby id is required");
+    }
+
+    // ========== GET OR CREATE TESTS ==========
+
+    @Test
+    void getOrCreateCreatesNewLobbyWhenNotExists() {
+        GameRoomState state = store.getOrCreate("new-lobby");
+
+        assertThat(state).isNotNull();
+        assertThat(state.getLobbyId()).isEqualTo("new-lobby");
+    }
+
+    @Test
+    void getOrCreateReturnsExistingLobby() {
+        GameRoomState existing = new GameRoomState();
+        existing.setLobbyId("lobby-1");
+        existing.setVersion(5L);
+        store.put("lobby-1", existing);
+
+        GameRoomState retrieved = store.getOrCreate("lobby-1");
+
+        assertThat(retrieved.getVersion()).isEqualTo(5L);
+    }
+
+    // ========== REMOVE TESTS ==========
+
+    @Test
+    void removeDeletesLobby() {
+        GameRoomState state = new GameRoomState();
+        store.put("lobby-1", state);
+
+        store.remove("lobby-1");
+
+        assertThat(store.get("lobby-1")).isEmpty();
+    }
+
+    @Test
+    void removeDoesNothingForNonExistentLobby() {
+        store.remove("non-existent");
+
+        assertThat(store.get("non-existent")).isEmpty();
+    }
+
+    @Test
+    void removeRejectsNullLobbyId() {
+        assertThatThrownBy(() -> store.remove(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Lobby id is required");
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/LobbyServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/LobbyServiceUnitTest.java
@@ -2,6 +2,7 @@ package at.aau.serg.websocketdemoserver.game;
 
 import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,23 +10,67 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LobbyServiceUnitTest {
 
-    @Test
-    void joinLobbyCreatesNewLobbyAndAddsPlayer() {
-        LobbyService service = new LobbyService(new InMemoryLobbyStore(), new CityDistributor());
+    private InMemoryLobbyStore store;
+    private LobbyService service;
 
-        GameRoomState state = service.joinLobby("lobby-1", "player-1");
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryLobbyStore();
+        service = new LobbyService(store, new CityDistributor());
+    }
+
+    // ========== CREATE LOBBY TESTS ==========
+
+    @Test
+    void createLobbyCreatesNewLobbyWithHost() {
+        GameRoomState state = service.createLobby("lobby-1", "host-player");
 
         assertThat(state.getLobbyId()).isEqualTo("lobby-1");
         assertThat(state.getPlayers()).hasSize(1);
-        assertThat(state.getPlayers().getFirst().getPlayerId()).isEqualTo("player-1");
+        assertThat(state.getPlayers().getFirst().getPlayerId()).isEqualTo("host-player");
         assertThat(state.getPhase()).isEqualTo(GamePhase.LOBBY);
+    }
+
+    @Test
+    void createLobbyStoresLobbyInStore() {
+        service.createLobby("lobby-1", "host-player");
+
+        assertThat(store.get("lobby-1")).isPresent();
+        assertThat(store.get("lobby-1").get().getPlayers()).hasSize(1);
+    }
+
+    @Test
+    void createLobbyRejectsDuplicateLobbyId() {
+        service.createLobby("lobby-1", "host-player");
+
+        assertThatThrownBy(() -> service.createLobby("lobby-1", "another-host"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already exists");
+    }
+
+    // ========== JOIN LOBBY TESTS ==========
+
+    @Test
+    void joinLobbyAddsPlayerToExistingLobby() {
+        service.createLobby("lobby-1", "host-player");
+
+        GameRoomState state = service.joinLobby("lobby-1", "player-2");
+
+        assertThat(state.getPlayers()).hasSize(2);
+        assertThat(state.getPlayers().get(1).getPlayerId()).isEqualTo("player-2");
         assertThat(state.getVersion()).isEqualTo(1L);
     }
 
     @Test
+    void joinLobbyRejectsNonExistentLobby() {
+        assertThatThrownBy(() -> service.joinLobby("non-existent", "player-1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist");
+    }
+
+    @Test
     void joinLobbyRejectsDuplicatePlayer() {
-        LobbyService service = new LobbyService(new InMemoryLobbyStore(), new CityDistributor());
-        service.joinLobby("lobby-1", "player-1");
+        service.createLobby("lobby-1", "player-1");
 
         assertThatThrownBy(() -> service.joinLobby("lobby-1", "player-1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -33,9 +78,39 @@ class LobbyServiceUnitTest {
     }
 
     @Test
+    void joinLobbyRejectsJoiningStartedGame() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1");
+
+        assertThatThrownBy(() -> service.joinLobby("lobby-1", "player-3"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot join started game");
+    }
+
+    @Test
+    void joinLobbyRejectsEmptyPlayerId() {
+        service.createLobby("lobby-1", "host");
+
+        assertThatThrownBy(() -> service.joinLobby("lobby-1", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Player id is required");
+    }
+
+    @Test
+    void joinLobbyRejectsNullPlayerId() {
+        service.createLobby("lobby-1", "host");
+
+        assertThatThrownBy(() -> service.joinLobby("lobby-1", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Player id is required");
+    }
+
+    // ========== START GAME TESTS ==========
+
+    @Test
     void startGameSetsInTurnPhaseAndCurrentPlayer() {
-        LobbyService service = new LobbyService(new InMemoryLobbyStore(), new CityDistributor());
-        service.joinLobby("lobby-1", "player-1");
+        service.createLobby("lobby-1", "player-1");
         service.joinLobby("lobby-1", "player-2");
 
         GameRoomState state = service.startGame("lobby-1");
@@ -43,13 +118,11 @@ class LobbyServiceUnitTest {
         assertThat(state.getPhase()).isEqualTo(GamePhase.IN_TURN);
         assertThat(state.getCurrentPlayerId()).isEqualTo("player-1");
         assertThat(state.getLastDiceValue()).isNull();
-        assertThat(state.getVersion()).isEqualTo(3L);
     }
 
     @Test
     void startGameRejectsLobbyWithLessThanTwoPlayers() {
-        LobbyService service = new LobbyService(new InMemoryLobbyStore(), new CityDistributor());
-        service.joinLobby("lobby-1", "player-1");
+        service.createLobby("lobby-1", "player-1");
 
         assertThatThrownBy(() -> service.startGame("lobby-1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -57,9 +130,28 @@ class LobbyServiceUnitTest {
     }
 
     @Test
+    void startGameRejectsNonExistentLobby() {
+        assertThatThrownBy(() -> service.startGame("non-existent"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void startGameRejectsAlreadyStartedGame() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1");
+
+        assertThatThrownBy(() -> service.startGame("lobby-1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already started");
+    }
+
+    // ========== LEAVE LOBBY TESTS ==========
+
+    @Test
     void leaveLobbyRemovesCurrentPlayerAndRotatesTurn() {
-        LobbyService service = new LobbyService(new InMemoryLobbyStore(), new CityDistributor());
-        service.joinLobby("lobby-1", "player-1");
+        service.createLobby("lobby-1", "player-1");
         service.joinLobby("lobby-1", "player-2");
         GameRoomState started = service.startGame("lobby-1");
         started.setLastDiceValue(5);
@@ -70,17 +162,30 @@ class LobbyServiceUnitTest {
         assertThat(state.getPlayers().getFirst().getPlayerId()).isEqualTo("player-2");
         assertThat(state.getCurrentPlayerId()).isEqualTo("player-2");
         assertThat(state.getLastDiceValue()).isNull();
-        assertThat(state.getVersion()).isEqualTo(4L);
     }
 
     @Test
     void leaveLobbyRemovesLobbyWhenLastPlayerLeaves() {
-        InMemoryLobbyStore store = new InMemoryLobbyStore();
-        LobbyService service = new LobbyService(store, new CityDistributor());
-        service.joinLobby("lobby-1", "player-1");
+        service.createLobby("lobby-1", "player-1");
 
         service.leaveLobby("lobby-1", "player-1");
 
         assertThat(store.get("lobby-1")).isEmpty();
+    }
+
+    @Test
+    void leaveLobbyRejectsNonExistentLobby() {
+        assertThatThrownBy(() -> service.leaveLobby("non-existent", "player-1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void leaveLobbyRejectsPlayerNotInLobby() {
+        service.createLobby("lobby-1", "player-1");
+
+        assertThatThrownBy(() -> service.leaveLobby("lobby-1", "player-2"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not in lobby");
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
@@ -16,6 +16,7 @@ class TurnBasedDtosUnitTest {
     @Test
     void commandTypeContainsExpectedValues() {
         assertThat(CommandType.values()).containsExactly(
+                CommandType.CREATE_LOBBY,
                 CommandType.JOIN_LOBBY,
                 CommandType.START_GAME,
                 CommandType.ROLL_DICE,

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerUnitTest.java
@@ -30,6 +30,39 @@ class WebSocketBrokerControllerUnitTest {
     private InMemoryLobbyStore lobbyStore;
 
     @Test
+    void handleLobbyCommandRoutesCreateLobbyAndReturnsSuccessResponse() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(CommandType.CREATE_LOBBY, null, "host-player", null);
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+
+        when(lobbyService.createLobby("lobby-1", "host-player")).thenReturn(state);
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getLobbyId()).isEqualTo("lobby-1");
+        assertThat(response.getCommandType()).isEqualTo(CommandType.CREATE_LOBBY);
+        assertThat(response.getState()).isEqualTo(state);
+        verify(lobbyService).createLobby("lobby-1", "host-player");
+    }
+
+    @Test
+    void handleLobbyCommandReturnsErrorWhenLobbyAlreadyExists() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(CommandType.CREATE_LOBBY, null, "host-player", null);
+
+        doThrow(new IllegalArgumentException("Lobby already exists"))
+                .when(lobbyService).createLobby("lobby-1", "host-player");
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).contains("already exists");
+        assertThat(response.getCommandType()).isEqualTo(CommandType.CREATE_LOBBY);
+    }
+
+    @Test
     void handleLobbyCommandRoutesJoinAndReturnsSuccessResponse() {
         WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
         ClientCommand command = new ClientCommand(CommandType.JOIN_LOBBY, null, "player-1", null);
@@ -45,6 +78,21 @@ class WebSocketBrokerControllerUnitTest {
         assertThat(response.getCommandType()).isEqualTo(CommandType.JOIN_LOBBY);
         assertThat(response.getState()).isEqualTo(state);
         verify(lobbyService).joinLobby("lobby-1", "player-1");
+    }
+
+    @Test
+    void handleLobbyCommandReturnsErrorWhenLobbyDoesNotExist() {
+        WebSocketBrokerController controller = new WebSocketBrokerController(lobbyService, gameCommandService, lobbyStore);
+        ClientCommand command = new ClientCommand(CommandType.JOIN_LOBBY, null, "player-1", null);
+
+        doThrow(new IllegalArgumentException("Lobby does not exist"))
+                .when(lobbyService).joinLobby("lobby-1", "player-1");
+
+        CommandResponse response = controller.handleLobbyCommand("lobby-1", command);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).contains("does not exist");
+        assertThat(response.getCommandType()).isEqualTo(CommandType.JOIN_LOBBY);
     }
 
     @Test


### PR DESCRIPTION
  Separate lobby creation from joining to properly handle the game flow.
  Previously joinLobby used getOrCreate which auto-created lobbies,
  allowing players to join non-existent games.

  - Add CREATE_LOBBY to CommandType enum
  - Add createLobby() method in LobbyService
  - Add put() method to InMemoryLobbyStore
  - Change joinLobby() to throw error if lobby doesn't exist
  - Handle CREATE_LOBBY in WebSocketBrokerController
  //Miswritten Server and server in terminal