### PR TITLE
 Implement round-based city distribution with random start color

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/game/CityDistributor.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/CityDistributor.java
@@ -1,10 +1,18 @@
 package at.aau.serg.websocketdemoserver.game;
 
 import at.aau.serg.websocketdemoserver.game.models.City;
+import at.aau.serg.websocketdemoserver.game.models.CityColor;
 import at.aau.serg.websocketdemoserver.game.models.Continent;
 import at.aau.serg.websocketdemoserver.game.models.PlayerState;
+import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
+import java.io.InputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -17,6 +25,8 @@ public class CityDistributor {
 
     private final Random random;
 
+    private List<City> allCities = new ArrayList<>();
+
     public CityDistributor() {
         this(new Random());
     }
@@ -26,6 +36,31 @@ public class CityDistributor {
      */
     public CityDistributor(Random random) {
         this.random = Objects.requireNonNull(random, "random must not be null");
+    }
+
+    @PostConstruct
+    public void loadCitiesFromJson() {
+        ObjectMapper mapper = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .build();
+
+        TypeReference<List<City>> typeReference = new TypeReference<>() {};
+        InputStream inputStream = getClass().getResourceAsStream("/cities.json");
+
+        try {
+            if (inputStream != null) {
+                allCities = mapper.readValue(inputStream, typeReference);
+            } else {
+                System.err.println("cities.json not found in resources");
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load cities.json: " + e.getMessage());
+        }
+    }
+
+    public List<City> getAllCities() {
+        return new ArrayList<>(allCities);
     }
 
     /**
@@ -60,8 +95,85 @@ public class CityDistributor {
                 if (currentPool != null) {
                     // Ziehe n Karten für diesen Spieler aus diesem Kontinent
                     for (int i = 0; i < amountPerContinent && !currentPool.isEmpty(); i++) {
-                        City pickedCity = currentPool.remove(0);
+                        City pickedCity = currentPool.removeFirst();
                         player.getOwnedCities().add(pickedCity);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Verteilt Städte fair an alle Spieler, aufgeteilt nach Farbe (ORANGE, RED, GREEN).
+     * Spielmodi: 6 Städte = 2 pro Farbe, 9 = 3 pro Farbe, 12 = 4 pro Farbe.
+     *
+     * @param allCities    Die Liste aller verfügbaren Städte.
+     * @param players      Die Liste der Spieler.
+     * @param amountPerColor Wie viele Städte jeder Spieler pro Farbe erhalten soll.
+     */
+    public void distributeByColor(List<City> allCities, List<PlayerState> players, int amountPerColor) {
+        if (players.isEmpty() || allCities.isEmpty()) {
+            return;
+        }
+        if (amountPerColor <= 0) {
+            throw new IllegalArgumentException("amountPerColor must be positive");
+        }
+
+        Map<CityColor, List<City>> colorPools = allCities.stream()
+                .collect(Collectors.groupingBy(City::getColor, HashMap::new, Collectors.toCollection(ArrayList::new)));
+
+        for (List<City> pool : colorPools.values()) {
+            Collections.shuffle(pool, random);
+        }
+
+        for (PlayerState player : players) {
+            for (CityColor color : CityColor.values()) {
+                List<City> currentPool = colorPools.get(color);
+                if (currentPool != null) {
+                    for (int i = 0; i < amountPerColor && !currentPool.isEmpty(); i++) {
+                        player.getOwnedCities().add(currentPool.removeFirst());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Verteilt Städte in Runden: In jeder Runde bekommt zunächst jeder Spieler eine Stadt der
+     * aktuellen Farbe, dann rotiert die Farbe (startColor → nächste → nächste → startColor …).
+     * Die erste Stadt jedes Spielers hat immer startColor — das ist dessen Startstadt.
+     *
+     * @param allCities      Die Liste aller verfügbaren Städte.
+     * @param players        Die Liste der Spieler.
+     * @param amountPerColor Wie viele Städte jeder Spieler pro Farbe erhalten soll.
+     * @param startColor     Die Farbe, mit der die Verteilung beginnt.
+     */
+    public void distributeByColorRounds(List<City> allCities, List<PlayerState> players, int amountPerColor, CityColor startColor) {
+        if (players.isEmpty() || allCities.isEmpty()) {
+            return;
+        }
+        if (amountPerColor <= 0) {
+            throw new IllegalArgumentException("amountPerColor must be positive");
+        }
+
+        CityColor[] allColors = CityColor.values();
+        int startIdx = startColor.ordinal();
+
+        Map<CityColor, List<City>> colorPools = allCities.stream()
+                .collect(Collectors.groupingBy(City::getColor, HashMap::new, Collectors.toCollection(ArrayList::new)));
+
+        for (List<City> pool : colorPools.values()) {
+            Collections.shuffle(pool, random);
+        }
+
+        for (int round = 0; round < amountPerColor; round++) {
+            for (int offset = 0; offset < allColors.length; offset++) {
+                CityColor color = allColors[(startIdx + offset) % allColors.length];
+                List<City> pool = colorPools.get(color);
+                if (pool == null) continue;
+                for (PlayerState player : players) {
+                    if (!pool.isEmpty()) {
+                        player.getOwnedCities().add(pool.removeFirst());
                     }
                 }
             }

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/LobbyService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/LobbyService.java
@@ -5,13 +5,12 @@ import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
 import at.aau.serg.websocketdemoserver.game.models.City;
 import at.aau.serg.websocketdemoserver.game.models.CityColor;
-import at.aau.serg.websocketdemoserver.game.models.Continent;
 import at.aau.serg.websocketdemoserver.game.models.PlayerState;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Random;
 
 /**
  * Service für das Verwalten der Spieler-Lobbys (Beitreten, Verlassen, Starten des Spiels).
@@ -23,6 +22,7 @@ public class LobbyService {
 
     private final InMemoryLobbyStore lobbyStore;
     private final CityDistributor cityDistributor;
+    private final Random random = new Random();
 
     public LobbyService(InMemoryLobbyStore lobbyStore, CityDistributor cityDistributor) {
         this.lobbyStore = Objects.requireNonNull(lobbyStore, "lobbyStore must not be null");
@@ -30,6 +30,7 @@ public class LobbyService {
     }
 
     public GameRoomState createLobby(String lobbyId, String playerId) {
+        validatePlayerId(playerId);
         if (lobbyStore.get(lobbyId).isPresent()) {
             throw new GameException(ErrorCode.GAME_ALREADY_STARTED, "Lobby already exists");
         }
@@ -109,57 +110,23 @@ public class LobbyService {
 
         state.setPhase(GamePhase.IN_TURN);
 
-        int continentCount = Continent.values().length;
-        int amountPerContinent = Math.max(1, stops / continentCount);
-        List<City> allCities = getDefaultCities();
-        cityDistributor.distributeByContinent(allCities, state.getPlayers(), amountPerContinent);
+        CityColor[] colors = CityColor.values();
+        CityColor startColor = colors[random.nextInt(colors.length)];
 
-        // 2. Setup initial positions (use first target city as start city for sprint 1 simplicity)
+        int amountPerColor = Math.max(1, stops / colors.length);
+        List<City> allCities = cityDistributor.getAllCities();
+        cityDistributor.distributeByColorRounds(allCities, state.getPlayers(), amountPerColor, startColor);
+
         for (PlayerState player : state.getPlayers()) {
-            if (!player.getOwnedCities().isEmpty()) {
-                City start = player.getOwnedCities().get(0);
-                player.setStartCity(start);
-                player.setCurrentCity(start);
-            }
+            City start = player.getOwnedCities().removeFirst();
+            player.setStartCity(start);
+            player.setCurrentCity(start);
         }
 
         state.setCurrentPlayerId(state.getPlayers().getFirst().getPlayerId());
         state.setLastDiceValue(null);
         state.setVersion(state.getVersion() + 1);
         return state;
-    }
-
-    private List<City> getDefaultCities() {
-        return new ArrayList<>(List.of(
-            // Europa
-            new City("wien", "Wien", Continent.EUROPE, CityColor.RED),
-            new City("berlin", "Berlin", Continent.EUROPE, CityColor.RED),
-            new City("paris", "Paris", Continent.EUROPE, CityColor.BLUE),
-            new City("rom", "Rom", Continent.EUROPE, CityColor.BLUE),
-            new City("madrid", "Madrid", Continent.EUROPE, CityColor.GREEN),
-            new City("london", "London", Continent.EUROPE, CityColor.GREEN),
-            // Asien
-            new City("tokio", "Tokio", Continent.ASIA, CityColor.RED),
-            new City("peking", "Peking", Continent.ASIA, CityColor.RED),
-            new City("bangkok", "Bangkok", Continent.ASIA, CityColor.BLUE),
-            new City("seoul", "Seoul", Continent.ASIA, CityColor.BLUE),
-            new City("neu-delhi", "Neu-Delhi", Continent.ASIA, CityColor.GREEN),
-            new City("singapur", "Singapur", Continent.ASIA, CityColor.GREEN),
-            // Nordamerika
-            new City("new-york", "New York", Continent.NORTH_AMERICA, CityColor.RED),
-            new City("los-angeles", "Los Angeles", Continent.NORTH_AMERICA, CityColor.RED),
-            new City("toronto", "Toronto", Continent.NORTH_AMERICA, CityColor.BLUE),
-            new City("chicago", "Chicago", Continent.NORTH_AMERICA, CityColor.BLUE),
-            new City("mexiko-stadt", "Mexiko-Stadt", Continent.NORTH_AMERICA, CityColor.GREEN),
-            new City("miami", "Miami", Continent.NORTH_AMERICA, CityColor.GREEN),
-            // Südamerika
-            new City("rio", "Rio de Janeiro", Continent.SOUTH_AMERICA, CityColor.RED),
-            new City("buenos-aires", "Buenos Aires", Continent.SOUTH_AMERICA, CityColor.RED),
-            new City("lima", "Lima", Continent.SOUTH_AMERICA, CityColor.BLUE),
-            new City("bogota", "Bogota", Continent.SOUTH_AMERICA, CityColor.BLUE),
-            new City("santiago", "Santiago", Continent.SOUTH_AMERICA, CityColor.GREEN),
-            new City("quito", "Quito", Continent.SOUTH_AMERICA, CityColor.GREEN)
-        ));
     }
 
     private boolean containsPlayer(List<PlayerState> players, String playerId) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/models/CityColor.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/models/CityColor.java
@@ -4,11 +4,7 @@ package at.aau.serg.websocketdemoserver.game.models;
  * Farbe einer Stadt auf dem Spielfeld (für Routen/Verbindungen).
  */
 public enum CityColor {
-    RED,
-    BLUE,
-    GREEN,
-    YELLOW,
     ORANGE,
-    BLACK,
-    WHITE
+    RED,
+    GREEN
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/CityDistributorTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/CityDistributorTest.java
@@ -37,29 +37,29 @@ class CityDistributorTest {
                 // Europa (6)
                 new City("wien", "Wien", Continent.EUROPE, CityColor.RED),
                 new City("berlin", "Berlin", Continent.EUROPE, CityColor.RED),
-                new City("paris", "Paris", Continent.EUROPE, CityColor.BLUE),
-                new City("rom", "Rom", Continent.EUROPE, CityColor.BLUE),
+                new City("paris", "Paris", Continent.EUROPE, CityColor.ORANGE),
+                new City("rom", "Rom", Continent.EUROPE, CityColor.ORANGE),
                 new City("madrid", "Madrid", Continent.EUROPE, CityColor.GREEN),
                 new City("london", "London", Continent.EUROPE, CityColor.GREEN),
                 // Asien (6)
                 new City("tokio", "Tokio", Continent.ASIA, CityColor.RED),
                 new City("peking", "Peking", Continent.ASIA, CityColor.RED),
-                new City("bangkok", "Bangkok", Continent.ASIA, CityColor.BLUE),
-                new City("seoul", "Seoul", Continent.ASIA, CityColor.BLUE),
+                new City("bangkok", "Bangkok", Continent.ASIA, CityColor.ORANGE),
+                new City("seoul", "Seoul", Continent.ASIA, CityColor.ORANGE),
                 new City("neu-delhi", "Neu-Delhi", Continent.ASIA, CityColor.GREEN),
                 new City("singapur", "Singapur", Continent.ASIA, CityColor.GREEN),
                 // Nordamerika (6)
                 new City("new-york", "New York", Continent.NORTH_AMERICA, CityColor.RED),
                 new City("los-angeles", "Los Angeles", Continent.NORTH_AMERICA, CityColor.RED),
-                new City("toronto", "Toronto", Continent.NORTH_AMERICA, CityColor.BLUE),
-                new City("chicago", "Chicago", Continent.NORTH_AMERICA, CityColor.BLUE),
+                new City("toronto", "Toronto", Continent.NORTH_AMERICA, CityColor.ORANGE),
+                new City("chicago", "Chicago", Continent.NORTH_AMERICA, CityColor.ORANGE),
                 new City("mexiko-stadt", "Mexiko-Stadt", Continent.NORTH_AMERICA, CityColor.GREEN),
                 new City("miami", "Miami", Continent.NORTH_AMERICA, CityColor.GREEN),
                 // Südamerika (6)
                 new City("rio", "Rio de Janeiro", Continent.SOUTH_AMERICA, CityColor.RED),
                 new City("buenos-aires", "Buenos Aires", Continent.SOUTH_AMERICA, CityColor.RED),
-                new City("lima", "Lima", Continent.SOUTH_AMERICA, CityColor.BLUE),
-                new City("bogota", "Bogota", Continent.SOUTH_AMERICA, CityColor.BLUE),
+                new City("lima", "Lima", Continent.SOUTH_AMERICA, CityColor.ORANGE),
+                new City("bogota", "Bogota", Continent.SOUTH_AMERICA, CityColor.ORANGE),
                 new City("santiago", "Santiago", Continent.SOUTH_AMERICA, CityColor.GREEN),
                 new City("quito", "Quito", Continent.SOUTH_AMERICA, CityColor.GREEN)
         ));
@@ -143,5 +143,153 @@ class CityDistributorTest {
 
         long uniqueCount = allAssigned.stream().distinct().count();
         assertEquals(allAssigned.size(), uniqueCount, "Keine Stadt darf doppelt vergeben werden");
+    }
+
+    // ========== distributeByColor Tests ==========
+
+    private List<City> colorTestCities() {
+        List<City> cities = new ArrayList<>();
+        for (int i = 1; i <= 6; i++) {
+            cities.add(new City("orange-" + i, "Orange " + i, Continent.EUROPE, CityColor.ORANGE));
+            cities.add(new City("red-" + i, "Red " + i, Continent.ASIA, CityColor.RED));
+            cities.add(new City("green-" + i, "Green " + i, Continent.NORTH_AMERICA, CityColor.GREEN));
+        }
+        return cities;
+    }
+
+    @Test
+    void distributeByColor_givesCorrectAmountPerColorForMultiplePlayers() {
+        distributor.distributeByColor(colorTestCities(), players, 2);
+
+        for (PlayerState player : players) {
+            assertEquals(6, player.getOwnedCities().size(),
+                    player.getPlayerId() + " sollte genau 6 Städte haben");
+
+            long orangeCount = player.getOwnedCities().stream().filter(c -> c.getColor() == CityColor.ORANGE).count();
+            long redCount    = player.getOwnedCities().stream().filter(c -> c.getColor() == CityColor.RED).count();
+            long greenCount  = player.getOwnedCities().stream().filter(c -> c.getColor() == CityColor.GREEN).count();
+
+            assertEquals(2, orangeCount, player.getPlayerId() + " hat nicht 2 ORANGE");
+            assertEquals(2, redCount,    player.getPlayerId() + " hat nicht 2 RED");
+            assertEquals(2, greenCount,  player.getPlayerId() + " hat nicht 2 GREEN");
+        }
+    }
+
+    @Test
+    void distributeByColor_noCityAssignedTwice() {
+        distributor.distributeByColor(colorTestCities(), players, 2);
+
+        List<City> allAssigned = new ArrayList<>();
+        for (PlayerState player : players) {
+            allAssigned.addAll(player.getOwnedCities());
+        }
+
+        long uniqueCount = allAssigned.stream().distinct().count();
+        assertEquals(allAssigned.size(), uniqueCount, "Keine Stadt darf doppelt vergeben werden");
+    }
+
+    @Test
+    void distributeByColor_handlesNotEnoughCitiesInPool() {
+        List<City> fewCities = new ArrayList<>(List.of(
+                new City("orange-1", "Orange 1", Continent.EUROPE, CityColor.ORANGE)
+        ));
+
+        distributor.distributeByColor(fewCities, players, 2);
+
+        assertEquals(1, players.get(0).getOwnedCities().size());
+        assertEquals(0, players.get(1).getOwnedCities().size());
+        assertEquals(0, players.get(2).getOwnedCities().size());
+    }
+
+    @Test
+    void distributeByColor_handlesEmptyCityList() {
+        distributor.distributeByColor(Collections.emptyList(), players, 2);
+
+        for (PlayerState player : players) {
+            assertEquals(0, player.getOwnedCities().size());
+        }
+    }
+
+    @Test
+    void distributeByColor_throwsOnInvalidAmount() {
+        assertThrows(IllegalArgumentException.class, () ->
+                distributor.distributeByColor(colorTestCities(), players, 0));
+        assertThrows(IllegalArgumentException.class, () ->
+                distributor.distributeByColor(colorTestCities(), players, -1));
+    }
+
+    // ========== distributeByColorRounds Tests ==========
+
+    @Test
+    void distributeByColorRounds_firstCityOfEachPlayerHasStartColor() {
+        for (CityColor startColor : CityColor.values()) {
+            players.forEach(p -> p.getOwnedCities().clear());
+            distributor.distributeByColorRounds(colorTestCities(), players, 2, startColor);
+
+            for (PlayerState player : players) {
+                assertEquals(startColor, player.getOwnedCities().getFirst().getColor(),
+                        player.getPlayerId() + " erste Stadt soll " + startColor + " sein");
+            }
+        }
+    }
+
+    @Test
+    void distributeByColorRounds_startCitiesAreUniqueAcrossPlayers() {
+        distributor.distributeByColorRounds(colorTestCities(), players, 2, CityColor.RED);
+
+        List<City> startCities = players.stream()
+                .map(p -> p.getOwnedCities().getFirst())
+                .toList();
+
+        long unique = startCities.stream().distinct().count();
+        assertEquals(startCities.size(), unique, "Jede Startstadt muss eindeutig sein");
+    }
+
+    @Test
+    void distributeByColorRounds_givesCorrectAmountPerColor() {
+        distributor.distributeByColorRounds(colorTestCities(), players, 2, CityColor.ORANGE);
+
+        for (PlayerState player : players) {
+            assertEquals(6, player.getOwnedCities().size(),
+                    player.getPlayerId() + " sollte genau 6 Städte haben");
+
+            long orangeCount = player.getOwnedCities().stream().filter(c -> c.getColor() == CityColor.ORANGE).count();
+            long redCount    = player.getOwnedCities().stream().filter(c -> c.getColor() == CityColor.RED).count();
+            long greenCount  = player.getOwnedCities().stream().filter(c -> c.getColor() == CityColor.GREEN).count();
+
+            assertEquals(2, orangeCount, player.getPlayerId() + " hat nicht 2 ORANGE");
+            assertEquals(2, redCount,    player.getPlayerId() + " hat nicht 2 RED");
+            assertEquals(2, greenCount,  player.getPlayerId() + " hat nicht 2 GREEN");
+        }
+    }
+
+    @Test
+    void distributeByColorRounds_noCityAssignedTwice() {
+        distributor.distributeByColorRounds(colorTestCities(), players, 2, CityColor.GREEN);
+
+        List<City> allAssigned = new ArrayList<>();
+        for (PlayerState player : players) {
+            allAssigned.addAll(player.getOwnedCities());
+        }
+
+        long uniqueCount = allAssigned.stream().distinct().count();
+        assertEquals(allAssigned.size(), uniqueCount, "Keine Stadt darf doppelt vergeben werden");
+    }
+
+    @Test
+    void distributeByColorRounds_throwsOnInvalidAmount() {
+        assertThrows(IllegalArgumentException.class, () ->
+                distributor.distributeByColorRounds(colorTestCities(), players, 0, CityColor.RED));
+        assertThrows(IllegalArgumentException.class, () ->
+                distributor.distributeByColorRounds(colorTestCities(), players, -1, CityColor.RED));
+    }
+
+    @Test
+    void distributeByColorRounds_handlesEmptyCityList() {
+        distributor.distributeByColorRounds(Collections.emptyList(), players, 2, CityColor.RED);
+
+        for (PlayerState player : players) {
+            assertEquals(0, player.getOwnedCities().size());
+        }
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
@@ -1,9 +1,7 @@
 package at.aau.serg.websocketdemoserver.game;
 
-import at.aau.serg.websocketdemoserver.game.GameException;
 import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
 import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
-import at.aau.serg.websocketdemoserver.messaging.dtos.ErrorCode;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
 import at.aau.serg.websocketdemoserver.game.models.City;
@@ -24,7 +22,7 @@ class GameCommandServiceUnitTest {
     @Test
     void rollDiceSetsDiceValueAndIncrementsVersion() {
         GameCommandService service = new GameCommandService(new FixedRandom(4));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
 
         service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
 
@@ -35,7 +33,7 @@ class GameCommandServiceUnitTest {
     @Test
     void rollDiceRejectsNonActivePlayer() {
         GameCommandService service = new GameCommandService(new FixedRandom(1));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
 
         assertThatThrownBy(() -> service.processCommand(
                 state,
@@ -47,7 +45,7 @@ class GameCommandServiceUnitTest {
     @Test
     void moveTokenRejectsWhenDiceWasNotRolled() {
         GameCommandService service = new GameCommandService(new FixedRandom(1));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
 
         assertThatThrownBy(() -> service.processCommand(
                 state,
@@ -59,7 +57,7 @@ class GameCommandServiceUnitTest {
     @Test
     void moveTokenRejectsWhenStepsDoNotMatchDiceValue() {
         GameCommandService service = new GameCommandService(new FixedRandom(3));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
         service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
 
         assertThatThrownBy(() -> service.processCommand(
@@ -72,13 +70,13 @@ class GameCommandServiceUnitTest {
     @Test
     void moveTokenAdvancesPositionRotatesTurnAndClearsDice() {
         GameCommandService service = new GameCommandService(new FixedRandom(2));
-        List<PlayerState> players = players("player-1", "player-2");
-        GameRoomState state = inTurnState("player-1", players);
+        List<PlayerState> players = defaultPlayers();
+        GameRoomState state = inTurnState(players);
         service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
 
         service.processCommand(state, new ClientCommand(CommandType.MOVE_TOKEN, "lobby-1", "player-1", 3, null));
 
-        assertThat(players.get(0).getBoardPosition()).isEqualTo(3);
+        assertThat(players.getFirst().getBoardPosition()).isEqualTo(3);
         assertThat(state.getCurrentPlayerId()).isEqualTo("player-2");
         assertThat(state.getLastDiceValue()).isNull();
         assertThat(state.getVersion()).isEqualTo(2L);
@@ -87,7 +85,7 @@ class GameCommandServiceUnitTest {
     @Test
     void moveTokenRejectsNonActivePlayer() {
         GameCommandService service = new GameCommandService(new FixedRandom(1));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
         service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
 
         assertThatThrownBy(() -> service.processCommand(
@@ -100,7 +98,7 @@ class GameCommandServiceUnitTest {
     @Test
     void rollDiceRejectsWhenDiceAlreadyRolled() {
         GameCommandService service = new GameCommandService(new FixedRandom(3));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
         service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
 
         assertThatThrownBy(() -> service.processCommand(
@@ -134,7 +132,7 @@ class GameCommandServiceUnitTest {
         GameCommandService service = new GameCommandService(new FixedRandom(1));
         GameRoomState state = new GameRoomState();
         state.setPhase(GamePhase.LOBBY);
-        state.setPlayers(players("player-1", "player-2"));
+        state.setPlayers(defaultPlayers());
         state.setCurrentPlayerId("player-1");
 
         assertThatThrownBy(() -> service.processCommand(
@@ -147,7 +145,7 @@ class GameCommandServiceUnitTest {
     @Test
     void moveTokenRejectsWhenMoveStepsNull() {
         GameCommandService service = new GameCommandService(new FixedRandom(3));
-        GameRoomState state = inTurnState("player-1", players("player-1", "player-2"));
+        GameRoomState state = inTurnState(defaultPlayers());
         service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
 
         assertThatThrownBy(() -> service.processCommand(
@@ -157,22 +155,22 @@ class GameCommandServiceUnitTest {
                 .hasMessageContaining("Move steps are required");
     }
 
-    private GameRoomState inTurnState(String currentPlayerId, List<PlayerState> players) {
+    private GameRoomState inTurnState(List<PlayerState> players) {
         GameRoomState state = new GameRoomState();
         state.setLobbyId("lobby-1");
         state.setPlayers(players);
         state.setPhase(GamePhase.IN_TURN);
-        state.setCurrentPlayerId(currentPlayerId);
+        state.setCurrentPlayerId("player-1");
         return state;
     }
 
-    private List<PlayerState> players(String firstPlayerId, String secondPlayerId) {
+    private List<PlayerState> defaultPlayers() {
         List<PlayerState> players = new ArrayList<>();
-        PlayerState p1 = new PlayerState(firstPlayerId);
+        PlayerState p1 = new PlayerState("player-1");
         p1.setCurrentCity(new City("vienna", "Vienna", Continent.EUROPE, CityColor.RED));
         players.add(p1);
-        PlayerState p2 = new PlayerState(secondPlayerId);
-        p2.setCurrentCity(new City("paris", "Paris", Continent.EUROPE, CityColor.BLUE));
+        PlayerState p2 = new PlayerState("player-2");
+        p2.setCurrentCity(new City("paris", "Paris", Continent.EUROPE, CityColor.GREEN));
         players.add(p2);
         return players;
     }

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/LobbyServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/LobbyServiceUnitTest.java
@@ -1,7 +1,5 @@
 package at.aau.serg.websocketdemoserver.game;
 
-import at.aau.serg.websocketdemoserver.game.GameException;
-import at.aau.serg.websocketdemoserver.game.LobbyLeaveResult;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +16,9 @@ class LobbyServiceUnitTest {
     @BeforeEach
     void setUp() {
         store = new InMemoryLobbyStore();
-        service = new LobbyService(store, new CityDistributor());
+        CityDistributor distributor = new CityDistributor();
+        distributor.loadCitiesFromJson();
+        service = new LobbyService(store, distributor);
     }
 
     // ========== CREATE LOBBY TESTS ==========
@@ -38,7 +38,7 @@ class LobbyServiceUnitTest {
         service.createLobby("lobby-1", "host-player");
 
         assertThat(store.get("lobby-1")).isPresent();
-        assertThat(store.get("lobby-1").get().getPlayers()).hasSize(1);
+        assertThat(store.get("lobby-1").orElseThrow().getPlayers()).hasSize(1);
     }
 
     @Test
@@ -282,8 +282,8 @@ class LobbyServiceUnitTest {
 
         GameRoomState state = service.startGame("lobby-1", 12);
 
-        assertThat(state.getPlayers().get(0).getOwnedCities()).isNotEmpty();
-        assertThat(state.getPlayers().get(0).getStartCity()).isNotNull();
-        assertThat(state.getPlayers().get(0).getCurrentCity()).isNotNull();
+        assertThat(state.getPlayers().getFirst().getOwnedCities()).isNotEmpty();
+        assertThat(state.getPlayers().getFirst().getStartCity()).isNotNull();
+        assertThat(state.getPlayers().getFirst().getCurrentCity()).isNotNull();
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/MovementEngineTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/MovementEngineTest.java
@@ -18,7 +18,6 @@ class MovementEngineTest {
 
     private CityNode berlin;
     private CityNode paris;
-    private CityNode london;
     private CityNode tokio;
 
     @BeforeEach
@@ -26,8 +25,8 @@ class MovementEngineTest {
         engine = new MovementEngine();
 
         berlin = new CityNode("berlin", "Berlin", Continent.EUROPE, CityColor.RED);
-        paris  = new CityNode("paris",  "Paris",  Continent.EUROPE, CityColor.BLUE);
-        london = new CityNode("london", "London", Continent.EUROPE, CityColor.GREEN);
+        paris  = new CityNode("paris",  "Paris",  Continent.EUROPE, CityColor.ORANGE);
+        CityNode london = new CityNode("london", "London", Continent.EUROPE, CityColor.GREEN);
         tokio  = new CityNode("tokio",  "Tokio",  Continent.ASIA,   CityColor.ORANGE);
 
         // Berlin --(Zug)--> Paris, Berlin --(Flug)--> Tokio, Berlin --(Zug)--> London

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/WorldGraphTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/WorldGraphTest.java
@@ -27,7 +27,7 @@ class WorldGraphTest {
                 "id": "paris",
                 "name": "Paris",
                 "continent": "EUROPE",
-                "color": "blue",
+                "color": "orange",
                 "trainConnections": [],
                 "flightConnections": ["berlin"],
                 "x": 0.0, "y": 0.0, "x_relativ": 0.0, "y_relativ": 0.0

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/models/CityNodeTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/models/CityNodeTest.java
@@ -13,7 +13,7 @@ class CityNodeTest {
     @BeforeEach
     void setup() {
         berlin = new CityNode("berlin", "Berlin", Continent.EUROPE, CityColor.RED);
-        paris  = new CityNode("paris",  "Paris",  Continent.EUROPE, CityColor.BLUE);
+        paris  = new CityNode("paris",  "Paris",  Continent.EUROPE, CityColor.ORANGE);
     }
 
     @Test
@@ -38,7 +38,7 @@ class CityNodeTest {
     @Test
     void addConnection_storesCorrectDestinationAndType() {
         berlin.addConnection(paris, ConnectionType.FLIGHT);
-        Connection conn = berlin.getConnections().get(0);
+        Connection conn = berlin.getConnections().getFirst();
 
         assertEquals("paris",           conn.getDestination().getId());
         assertEquals(ConnectionType.FLIGHT, conn.getType());


### PR DESCRIPTION
  - Add distributeByColorRounds to CityDistributor: distributes cities in rounds so all players receive one city per color before rotating, ensuring each player's first city (= startCity) is of the same randomly chosen color but a unique city
  - startCity is removed from ownedCities so stops=6 yields exactly 5 ownedCities + 1 startCity, not 7
  - Reduce CityColor enum to ORANGE, RED, GREEN to match cities.json
  - Add JSON loading and getAllCities() to CityDistributor
  - Add distributeByColorRounds tests (start color, uniqueness, counts)