### PR TITLE
Lobby-Spielmodus im Server unterstützen

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -3,6 +3,7 @@ package at.aau.serg.websocketdemoserver.game;
 import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
 import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
 import at.aau.serg.websocketdemoserver.messaging.dtos.ErrorCode;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameMode;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
 import at.aau.serg.websocketdemoserver.game.models.City;
@@ -56,6 +57,12 @@ public class GameCommandService {
 
     public void processCommand(GameRoomState state, ClientCommand command) {
         validateBase(state, command);
+
+        if(command.getType() == CommandType.UPDATE_GAME_MODE){
+            handleUpdateGameMode(state, command);
+            return;
+        }
+
         if (command.getType() == CommandType.ROLL_DICE) {
             handleRollDice(state, command);
             return;
@@ -77,6 +84,25 @@ public class GameCommandService {
         }
 
         throw new GameException(ErrorCode.UNSUPPORTED_COMMAND_TYPE, "Unsupported command type for turn flow");
+    }
+
+    private void handleUpdateGameMode(GameRoomState state, ClientCommand command) {
+        if(state.getPhase() != GamePhase.LOBBY) {
+            throw new GameException(ErrorCode.INVALID_PHASE, "Gamemode can only be changed in lobby phase");
+        }
+
+        if(state.getHostId() == null || !state.getHostId().equals(command.getPlayerId())){
+            throw new GameException(ErrorCode.INVALID_COMMAND, "Only the host can change the game mode");
+        }
+
+        GameMode selectedGameMode = command.getGameMode();
+
+        if(selectedGameMode == null){
+            throw new GameException(ErrorCode.INVALID_COMMAND, "Game mode is required");
+        }
+
+        state.setGameMode(selectedGameMode);
+        state.setVersion(state.getVersion() + 1);
     }
 
     private void handleRollDice(GameRoomState state, ClientCommand command) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/ClientCommand.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/ClientCommand.java
@@ -17,8 +17,9 @@ public class ClientCommand {
     private Integer moveSteps;
     private Integer stops;
     private String targetCityId;
+    private GameMode gameMode;
 
     public ClientCommand(CommandType type, String lobbyId, String playerId, Integer moveSteps, Integer stops) {
-        this(type, lobbyId, playerId, moveSteps, stops, null);
+        this(type, lobbyId, playerId, moveSteps, stops, null, null);
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
@@ -7,6 +7,7 @@ public enum CommandType {
     CREATE_LOBBY,
     JOIN_LOBBY,
     START_GAME,
+    UPDATE_GAME_MODE,
     ROLL_DICE,
     MOVE_TOKEN,
     MOVE_TO_CITY,

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameMode.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameMode.java
@@ -1,0 +1,23 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+public enum GameMode {
+    CITY_HOPPER("City Hopper", 6),
+    GRAND_TOUR("Grand Tour", 9),
+    EPIC_VOYAGE("Epic Voyage", 12);
+
+    private final String displayName;
+    private final int stops;
+
+    GameMode(String displayName, int stops) {
+        this.displayName = displayName;
+        this.stops = stops;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public int getStops() {
+        return stops;
+    }
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameRoomState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameRoomState.java
@@ -26,8 +26,10 @@ public class GameRoomState {
     private long version = 0L;
     private List<String> validMoveIds = new ArrayList<>();
 
+    private GameMode gameMode = GameMode.CITY_HOPPER;
+
     public GameRoomState(String lobbyId, String hostId, List<PlayerState> players,
                          GamePhase phase, String currentPlayerId, Integer lastDiceValue, long version) {
-        this(lobbyId, hostId, players, phase, currentPlayerId, lastDiceValue, version, new ArrayList<>());
+        this(lobbyId, hostId, players, phase, currentPlayerId, lastDiceValue, version, new ArrayList<>(), GameMode.CITY_HOPPER);
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -80,7 +80,25 @@ public class WebSocketBrokerController {
                     registerSession(headerAccessor, lobbyId, command.getPlayerId());
                     yield s;
                 }
-                case START_GAME -> lobbyService.startGame(lobbyId, command.getStops() != null ? command.getStops() : 12);
+                case UPDATE_GAME_MODE -> {
+                    GameRoomState existingState = lobbyStore.get(lobbyId)
+                            .orElseThrow(() -> new GameException(ErrorCode.LOBBY_NOT_FOUND, "Lobby not found"));
+                    gameCommandService.processCommand(existingState, command);
+                    yield existingState;
+                }
+                case START_GAME -> {
+                    int stops = command.getStops() != null ? command.getStops() : 12;
+
+                    var existingState = lobbyStore.get(lobbyId);
+
+                    if (existingState != null
+                            && existingState.isPresent()
+                            && existingState.get().getGameMode() != null) {
+                        stops = existingState.get().getGameMode().getStops();
+                    }
+
+                    yield lobbyService.startGame(lobbyId, stops);
+                }
                 case ROLL_DICE, MOVE_TOKEN, MOVE_TO_CITY, END_TURN -> {
                     GameRoomState existingState = lobbyStore.get(lobbyId)
                             .orElseThrow(() -> new GameException(ErrorCode.LOBBY_NOT_FOUND, "Lobby not found"));

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
@@ -2,6 +2,7 @@ package at.aau.serg.websocketdemoserver.game;
 
 import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
 import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameMode;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
 import at.aau.serg.websocketdemoserver.game.models.City;
@@ -154,6 +155,50 @@ class GameCommandServiceUnitTest {
                 .isInstanceOf(GameException.class)
                 .hasMessageContaining("Move steps are required");
     }
+
+    @Test
+    void hostCanUpdateGameModeInLobbyPhase() {
+        GameCommandService service = new GameCommandService(new FixedRandom(1));
+
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+        state.setHostId("host-1");
+        state.setPhase(GamePhase.LOBBY);
+        state.setGameMode(GameMode.CITY_HOPPER);
+        state.setVersion(0L);
+
+        ClientCommand command = new ClientCommand(CommandType.UPDATE_GAME_MODE, "lobby-1", "host-1", null, null);
+        command.setGameMode(GameMode.GRAND_TOUR);
+
+        service.processCommand(state, command);
+
+        assertThat(state.getGameMode()).isEqualTo(GameMode.GRAND_TOUR);
+        assertThat(state.getGameMode().getStops()).isEqualTo(9);
+        assertThat(state.getVersion()).isEqualTo(1L);
+    }
+
+    @Test
+    void nonHostCannotUpdateGameMode() {
+        GameCommandService service = new GameCommandService(new FixedRandom(1));
+
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+        state.setHostId("host-1");
+        state.setPhase(GamePhase.LOBBY);
+        state.setGameMode(GameMode.CITY_HOPPER);
+        state.setVersion(0L);
+
+        ClientCommand command = new ClientCommand(CommandType.UPDATE_GAME_MODE, "lobby-1", "player-2", null, null);
+        command.setGameMode(GameMode.EPIC_VOYAGE);
+
+        assertThatThrownBy(() -> service.processCommand(state, command))
+                .isInstanceOf(GameException.class)
+                .hasMessageContaining("Only the host can change the game mode");
+
+        assertThat(state.getGameMode()).isEqualTo(GameMode.CITY_HOPPER);
+        assertThat(state.getVersion()).isEqualTo(0L);
+    }
+
 
     private GameRoomState inTurnState(List<PlayerState> players) {
         GameRoomState state = new GameRoomState();

--- a/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
@@ -19,6 +19,7 @@ class TurnBasedDtosUnitTest {
                 CommandType.CREATE_LOBBY,
                 CommandType.JOIN_LOBBY,
                 CommandType.START_GAME,
+                CommandType.UPDATE_GAME_MODE,
                 CommandType.ROLL_DICE,
                 CommandType.MOVE_TOKEN,
                 CommandType.MOVE_TO_CITY,


### PR DESCRIPTION
Dieser Pull Request ergänzt die serverseitige Unterstützung für Issue #65.

Änderungen:
- GameMode-Enum für City Hopper, Grand Tour und Epic Voyage hinzugefügt
- GameRoomState speichert den ausgewählten Spielmodus
- ClientCommand und CommandType für UPDATE_GAME_MODE erweitert
- GameCommandService verarbeitet Spielmodus-Updates
- WebSocketBrokerController verarbeitet UPDATE_GAME_MODE
- Beim Spielstart werden die Stops aus dem ausgewählten GameMode verwendet
- Tests ergänzt und angepasst

Getestet:
- Server lokal gestartet
- Spielmodus-Update über die Android-App getestet
- Server-State aktualisiert sich korrekt, z. B. auf EPIC_VOYAGE

Closes #65