### PR TITLE
Feature/goal reached logic

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -4,13 +4,18 @@ import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
 import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
 import at.aau.serg.websocketdemoserver.messaging.dtos.ErrorCode;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameMode;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameOverMessage;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
 import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GoalReachedMessage;
+import at.aau.serg.websocketdemoserver.messaging.dtos.PlayerScore;
 import at.aau.serg.websocketdemoserver.game.models.City;
 import at.aau.serg.websocketdemoserver.game.models.CityNode;
 import at.aau.serg.websocketdemoserver.game.models.Connection;
 import at.aau.serg.websocketdemoserver.game.models.PlayerState;
+import at.aau.serg.websocketdemoserver.websocket.broker.WebSocketTopics;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,24 +32,30 @@ public class GameCommandService {
     private final Random random;
     private final WorldGraph worldGraph;
     private final MovementEngine movementEngine;
+    private final GameSessionService gameSessionService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     public GameCommandService() {
-        this(new Random(), loadWorldGraphSafe(), new MovementEngine());
+        this(new Random(), loadWorldGraphSafe(), new MovementEngine(), new GameSessionService(), null);
     }
 
     public GameCommandService(Random random) {
-        this(random, loadWorldGraphSafe(), new MovementEngine());
+        this(random, loadWorldGraphSafe(), new MovementEngine(), new GameSessionService(), null);
     }
 
     @Autowired
-    public GameCommandService(WorldGraph worldGraph, MovementEngine movementEngine) {
-        this(new Random(), worldGraph, movementEngine);
+    public GameCommandService(WorldGraph worldGraph, MovementEngine movementEngine,
+                               GameSessionService gameSessionService, SimpMessagingTemplate messagingTemplate) {
+        this(new Random(), worldGraph, movementEngine, gameSessionService, messagingTemplate);
     }
 
-    GameCommandService(Random random, WorldGraph worldGraph, MovementEngine movementEngine) {
+    GameCommandService(Random random, WorldGraph worldGraph, MovementEngine movementEngine,
+                       GameSessionService gameSessionService, SimpMessagingTemplate messagingTemplate) {
         this.random = Objects.requireNonNull(random, "random must not be null");
         this.worldGraph = Objects.requireNonNull(worldGraph, "worldGraph must not be null");
         this.movementEngine = Objects.requireNonNull(movementEngine, "movementEngine must not be null");
+        this.gameSessionService = Objects.requireNonNull(gameSessionService, "gameSessionService must not be null");
+        this.messagingTemplate = messagingTemplate;
     }
 
     private static WorldGraph loadWorldGraphSafe() {
@@ -58,7 +69,7 @@ public class GameCommandService {
     public void processCommand(GameRoomState state, ClientCommand command) {
         validateBase(state, command);
 
-        if(command.getType() == CommandType.UPDATE_GAME_MODE){
+        if (command.getType() == CommandType.UPDATE_GAME_MODE) {
             handleUpdateGameMode(state, command);
             return;
         }
@@ -87,17 +98,17 @@ public class GameCommandService {
     }
 
     private void handleUpdateGameMode(GameRoomState state, ClientCommand command) {
-        if(state.getPhase() != GamePhase.LOBBY) {
+        if (state.getPhase() != GamePhase.LOBBY) {
             throw new GameException(ErrorCode.INVALID_PHASE, "Gamemode can only be changed in lobby phase");
         }
 
-        if(state.getHostId() == null || !state.getHostId().equals(command.getPlayerId())){
+        if (state.getHostId() == null || !state.getHostId().equals(command.getPlayerId())) {
             throw new GameException(ErrorCode.INVALID_COMMAND, "Only the host can change the game mode");
         }
 
         GameMode selectedGameMode = command.getGameMode();
 
-        if(selectedGameMode == null){
+        if (selectedGameMode == null) {
             throw new GameException(ErrorCode.INVALID_COMMAND, "Game mode is required");
         }
 
@@ -188,7 +199,19 @@ public class GameCommandService {
         player.setRemainingSteps(newRemainingSteps);
 
         CityNode targetNode = chosenConnection.getDestination();
-        player.setCurrentCity(new City(targetNode.getId(), targetNode.getName(), targetNode.getContinent(), targetNode.getColor()));
+        City targetCity = new City(targetNode.getId(), targetNode.getName(), targetNode.getContinent(), targetNode.getColor());
+
+        int goalsBefore = player.getVisitedCities().size();
+        gameSessionService.visitCity(player, targetCity);
+
+        if (player.getVisitedCities().size() > goalsBefore) {
+            broadcastGoalReached(state, player, targetCity);
+        }
+
+        if (!state.isGameOver() && gameSessionService.isVictory(player)) {
+            state.setGameOver(true);
+            broadcastGameOver(state);
+        }
 
         if (newRemainingSteps <= 0) {
             player.setRemainingSteps(0);
@@ -221,6 +244,31 @@ public class GameCommandService {
         state.setCurrentPlayerId(nextPlayerId);
         state.setLastDiceValue(null);
         state.setVersion(state.getVersion() + 1);
+    }
+
+    private void broadcastGoalReached(GameRoomState state, PlayerState player, City city) {
+        if (messagingTemplate == null) return;
+        GoalReachedMessage message = new GoalReachedMessage(
+                player.getPlayerId(),
+                city.getName(),
+                player.getVisitedCities().size(),
+                player.getOwnedCities().size()
+        );
+        messagingTemplate.convertAndSend(WebSocketTopics.GOAL_REACHED, message);
+    }
+
+    private void broadcastGameOver(GameRoomState state) {
+        if (messagingTemplate == null) return;
+        List<PlayerScore> scores = state.getPlayers().stream()
+                .map(p -> new PlayerScore(p.getPlayerId(), calculateScore(p)))
+                .collect(Collectors.toList());
+        messagingTemplate.convertAndSend(WebSocketTopics.GAME_OVER, new GameOverMessage(scores));
+    }
+
+    int calculateScore(PlayerState player) {
+        int reached = player.getVisitedCities().size();
+        int remaining = player.getOwnedCities().size() - reached;
+        return reached - remaining;
     }
 
     private void recomputeValidMoveIds(GameRoomState state) {
@@ -280,6 +328,9 @@ public class GameCommandService {
     }
 
     private void validateTurnContext(GameRoomState state, ClientCommand command) {
+        if (state.isGameOver()) {
+            throw new GameException(ErrorCode.GAME_OVER, "Das Spiel ist bereits beendet");
+        }
         if (state.getPhase() != GamePhase.IN_TURN) {
             throw new GameException(ErrorCode.INVALID_PHASE, "Command not allowed in current phase");
         }

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -205,7 +205,7 @@ public class GameCommandService {
         gameSessionService.visitCity(player, targetCity);
 
         if (player.getVisitedCities().size() > goalsBefore) {
-            broadcastGoalReached(state, player, targetCity);
+            broadcastGoalReached(player, targetCity);
         }
 
         if (!state.isGameOver() && gameSessionService.isVictory(player)) {
@@ -243,10 +243,11 @@ public class GameCommandService {
         String nextPlayerId = nextPlayerId(state.getPlayers(), state.getCurrentPlayerId());
         state.setCurrentPlayerId(nextPlayerId);
         state.setLastDiceValue(null);
+        recomputeValidMoveIds(state);
         state.setVersion(state.getVersion() + 1);
     }
 
-    private void broadcastGoalReached(GameRoomState state, PlayerState player, City city) {
+    private void broadcastGoalReached(PlayerState player, City city) {
         if (messagingTemplate == null) return;
         GoalReachedMessage message = new GoalReachedMessage(
                 player.getPlayerId(),

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -215,6 +215,7 @@ public class GameCommandService {
 
         if (newRemainingSteps <= 0) {
             player.setRemainingSteps(0);
+            player.setPreviousCityId(null);
             String nextPlayerId = nextPlayerId(state.getPlayers(), state.getCurrentPlayerId());
             state.setCurrentPlayerId(nextPlayerId);
             state.setLastDiceValue(null);

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/LobbyService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/LobbyService.java
@@ -129,6 +129,34 @@ public class LobbyService {
         return state;
     }
 
+    public GameRoomState resetLobby(String lobbyId, String playerId) {
+        validatePlayerId(playerId);
+        GameRoomState state = lobbyStore.get(lobbyId)
+                .orElseThrow(() -> new GameException(ErrorCode.LOBBY_NOT_FOUND, "Lobby not found"));
+
+        if (!playerId.equals(state.getHostId())) {
+            throw new GameException(ErrorCode.MISSING_PLAYER_ID, "Only the host can reset the lobby");
+        }
+
+        for (PlayerState player : state.getPlayers()) {
+            player.setStartCity(null);
+            player.setCurrentCity(null);
+            player.setPreviousCityId(null);
+            player.setBoardPosition(0);
+            player.setRemainingSteps(0);
+            player.getOwnedCities().clear();
+            player.getVisitedCities().clear();
+        }
+
+        state.setPhase(GamePhase.LOBBY);
+        state.setCurrentPlayerId(null);
+        state.setLastDiceValue(null);
+        state.getValidMoveIds().clear();
+        state.setGameOver(false);
+        state.setVersion(state.getVersion() + 1);
+        return state;
+    }
+
     private boolean containsPlayer(List<PlayerState> players, String playerId) {
         return players.stream().anyMatch(player -> playerId.equals(player.getPlayerId()));
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/CommandType.java
@@ -13,5 +13,6 @@ public enum CommandType {
     MOVE_TO_CITY,
     END_TURN,
     LEAVE_LOBBY,
-    LOBBY_CLOSED
+    LOBBY_CLOSED,
+    RESET_LOBBY
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/ErrorCode.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/ErrorCode.java
@@ -21,5 +21,6 @@ public enum ErrorCode {
     INTERNAL_ERROR,
     LOBBY_FULL,
     CITY_NOT_FOUND,
-    INVALID_MOVE_TARGET
+    INVALID_MOVE_TARGET,
+    GAME_OVER
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameOverMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameOverMessage.java
@@ -1,0 +1,14 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameOverMessage {
+    private List<PlayerScore> scores;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameRoomState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameRoomState.java
@@ -27,9 +27,10 @@ public class GameRoomState {
     private List<String> validMoveIds = new ArrayList<>();
 
     private GameMode gameMode = GameMode.CITY_HOPPER;
+    private boolean gameOver = false;
 
     public GameRoomState(String lobbyId, String hostId, List<PlayerState> players,
                          GamePhase phase, String currentPlayerId, Integer lastDiceValue, long version) {
-        this(lobbyId, hostId, players, phase, currentPlayerId, lastDiceValue, version, new ArrayList<>(), GameMode.CITY_HOPPER);
+        this(lobbyId, hostId, players, phase, currentPlayerId, lastDiceValue, version, new ArrayList<>(), GameMode.CITY_HOPPER, false);
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GoalReachedMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GoalReachedMessage.java
@@ -1,0 +1,15 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GoalReachedMessage {
+    private String playerName;
+    private String cityName;
+    private int reached;
+    private int total;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/PlayerScore.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/PlayerScore.java
@@ -1,0 +1,13 @@
+package at.aau.serg.websocketdemoserver.messaging.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlayerScore {
+    private String playerName;
+    private int score;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -99,6 +99,7 @@ public class WebSocketBrokerController {
 
                     yield lobbyService.startGame(lobbyId, stops);
                 }
+                case RESET_LOBBY -> lobbyService.resetLobby(lobbyId, command.getPlayerId());
                 case ROLL_DICE, MOVE_TOKEN, MOVE_TO_CITY, END_TURN -> {
                     GameRoomState existingState = lobbyStore.get(lobbyId)
                             .orElseThrow(() -> new GameException(ErrorCode.LOBBY_NOT_FOUND, "Lobby not found"));

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketTopics.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketTopics.java
@@ -1,0 +1,13 @@
+package at.aau.serg.websocketdemoserver.websocket.broker;
+
+public final class WebSocketTopics {
+
+    private WebSocketTopics() {}
+
+    public static final String GOAL_REACHED = "/topic/goal-reached";
+    public static final String GAME_OVER = "/topic/game-over";
+
+    public static String lobbyEvents(String lobbyId) {
+        return "/topic/lobby/" + lobbyId + "/events";
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
@@ -200,6 +200,19 @@ class GameCommandServiceUnitTest {
     }
 
 
+    @Test
+    void endTurnClearsValidMoveIds() {
+        GameCommandService service = new GameCommandService(new FixedRandom(2));
+        GameRoomState state = inTurnState(defaultPlayers());
+        state.setLastDiceValue(3);
+        state.getPlayers().getFirst().setRemainingSteps(3);
+        state.setValidMoveIds(new ArrayList<>(List.of("some-city-id")));
+
+        service.processCommand(state, new ClientCommand(CommandType.END_TURN, "lobby-1", "player-1", null, null));
+
+        assertThat(state.getValidMoveIds()).isEmpty();
+    }
+
     private GameRoomState inTurnState(List<PlayerState> players) {
         GameRoomState state = new GameRoomState();
         state.setLobbyId("lobby-1");

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GameCommandServiceUnitTest.java
@@ -201,6 +201,32 @@ class GameCommandServiceUnitTest {
 
 
     @Test
+    void previousCityIdClearedAfterAutoTurnSwitch_allowsReturnInNextTurn() {
+        // Single-player game so the auto-switch immediately returns to player-1.
+        // novosibirsk –train(1)– omsk: rolling 1 uses up all steps and triggers auto-switch.
+        GameCommandService service = new GameCommandService(new FixedRandom(0)); // dice always = 1
+        PlayerState p1 = new PlayerState("player-1");
+        p1.setCurrentCity(new City("novosibirsk", "Novosibirsk", Continent.ASIA, CityColor.ORANGE));
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId("lobby-1");
+        state.setPlayers(new ArrayList<>(List.of(p1)));
+        state.setPhase(GamePhase.IN_TURN);
+        state.setCurrentPlayerId("player-1");
+
+        // Turn 1: roll 1, move novosibirsk → omsk (cost=1, steps hit 0 → auto-switch)
+        service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
+        ClientCommand moveCmd = new ClientCommand(CommandType.MOVE_TO_CITY, "lobby-1", "player-1", null, null, "omsk", null);
+        service.processCommand(state, moveCmd);
+
+        // Auto-switch returns to player-1 (only player). previousCityId must be null now.
+        assertThat(p1.getPreviousCityId()).isNull();
+
+        // Turn 2: roll again — novosibirsk must appear in validMoveIds (no U-turn block)
+        service.processCommand(state, new ClientCommand(CommandType.ROLL_DICE, "lobby-1", "player-1", null, null));
+        assertThat(state.getValidMoveIds()).contains("novosibirsk");
+    }
+
+    @Test
     void endTurnClearsValidMoveIds() {
         GameCommandService service = new GameCommandService(new FixedRandom(2));
         GameRoomState state = inTurnState(defaultPlayers());

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GoalAndGameOverUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GoalAndGameOverUnitTest.java
@@ -1,0 +1,334 @@
+package at.aau.serg.websocketdemoserver.game;
+
+import at.aau.serg.websocketdemoserver.messaging.dtos.ClientCommand;
+import at.aau.serg.websocketdemoserver.messaging.dtos.CommandType;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameOverMessage;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GamePhase;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GameRoomState;
+import at.aau.serg.websocketdemoserver.messaging.dtos.GoalReachedMessage;
+import at.aau.serg.websocketdemoserver.game.models.City;
+import at.aau.serg.websocketdemoserver.game.models.CityColor;
+import at.aau.serg.websocketdemoserver.game.models.CityNode;
+import at.aau.serg.websocketdemoserver.game.models.Connection;
+import at.aau.serg.websocketdemoserver.game.models.ConnectionType;
+import at.aau.serg.websocketdemoserver.game.models.Continent;
+import at.aau.serg.websocketdemoserver.game.models.PlayerState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GoalAndGameOverUnitTest {
+
+    @Mock
+    private MovementEngine movementEngine;
+
+    @Mock
+    private WorldGraph worldGraph;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private GameSessionService gameSessionService;
+    private GameCommandService service;
+
+    private static final String LOBBY_ID = "lobby-1";
+    private static final String PLAYER_ID = "player-1";
+
+    @BeforeEach
+    void setUp() {
+        gameSessionService = new GameSessionService();
+        service = new GameCommandService(new Random(), worldGraph, movementEngine, gameSessionService, messagingTemplate);
+    }
+
+    // ===== Goal-reached tests =====
+
+    @Test
+    void moveToBucketListCity_marksGoalAndBroadcasts() {
+        City vienna = city("vienna", "Vienna");
+        City paris = city("paris", "Paris");
+
+        CityNode viennaNode = cityNode("vienna", "Vienna");
+        CityNode parisNode = cityNode("paris", "Paris");
+
+        PlayerState player = playerAt(vienna);
+        player.setStartCity(vienna);
+        player.setRemainingSteps(1);
+        player.getOwnedCities().add(paris);
+
+        when(worldGraph.getCityById("vienna")).thenReturn(viennaNode);
+        when(movementEngine.getValidOptions(any(), any(), anyInt(), any()))
+                .thenReturn(List.of(new Connection(parisNode, ConnectionType.TRAIN)));
+
+        GameRoomState state = inTurnState(List.of(player));
+        state.setLastDiceValue(1);
+
+        service.processCommand(state, moveToCityCommand("paris"));
+
+        assertThat(player.getVisitedCities()).extracting(City::getId).containsExactly("paris");
+
+        ArgumentCaptor<GoalReachedMessage> captor = ArgumentCaptor.forClass(GoalReachedMessage.class);
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/goal-reached"), captor.capture());
+
+        GoalReachedMessage msg = captor.getValue();
+        assertThat(msg.getPlayerName()).isEqualTo(PLAYER_ID);
+        assertThat(msg.getCityName()).isEqualTo("Paris");
+        assertThat(msg.getReached()).isEqualTo(1);
+        assertThat(msg.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    void moveToNonTargetCity_noGoalBroadcast() {
+        City vienna = city("vienna", "Vienna");
+        City berlin = city("berlin", "Berlin");
+        City paris = city("paris", "Paris");
+
+        CityNode viennaNode = cityNode("vienna", "Vienna");
+        CityNode berlinNode = cityNode("berlin", "Berlin");
+
+        PlayerState player = playerAt(vienna);
+        player.setRemainingSteps(1);
+        player.getOwnedCities().add(paris);
+
+        when(worldGraph.getCityById("vienna")).thenReturn(viennaNode);
+        when(movementEngine.getValidOptions(any(), any(), anyInt(), any()))
+                .thenReturn(List.of(new Connection(berlinNode, ConnectionType.TRAIN)));
+
+        GameRoomState state = inTurnState(List.of(player));
+        state.setLastDiceValue(1);
+
+        service.processCommand(state, moveToCityCommand("berlin"));
+
+        assertThat(player.getVisitedCities()).isEmpty();
+        verify(messagingTemplate, never()).convertAndSend(any(String.class), any(GoalReachedMessage.class));
+    }
+
+    @Test
+    void moveToAlreadyVisitedTarget_noSecondBroadcast() {
+        City vienna = city("vienna", "Vienna");
+        City paris = city("paris", "Paris");
+
+        CityNode viennaNode = cityNode("vienna", "Vienna");
+        CityNode parisNode = cityNode("paris", "Paris");
+
+        PlayerState player = playerAt(vienna);
+        player.setStartCity(vienna);
+        player.setRemainingSteps(1);
+        player.getOwnedCities().add(paris);
+        player.getVisitedCities().add(paris);
+
+        when(worldGraph.getCityById("vienna")).thenReturn(viennaNode);
+        when(movementEngine.getValidOptions(any(), any(), anyInt(), any()))
+                .thenReturn(List.of(new Connection(parisNode, ConnectionType.TRAIN)));
+
+        GameRoomState state = inTurnState(List.of(player));
+        state.setLastDiceValue(1);
+
+        service.processCommand(state, moveToCityCommand("paris"));
+
+        verify(messagingTemplate, never()).convertAndSend(any(String.class), any(GoalReachedMessage.class));
+    }
+
+    // ===== Game-over triggered by visiting last target that is also startCity =====
+
+    @Test
+    void visitLastTargetAndAtStartCity_triggersGameOver() {
+        City vienna = city("vienna", "Vienna");
+
+        CityNode someNode = cityNode("other", "Other");
+        CityNode viennaNode = cityNode("vienna", "Vienna");
+
+        PlayerState player = playerAt(city("other", "Other"));
+        player.setStartCity(vienna);
+        player.setRemainingSteps(1);
+        player.getOwnedCities().add(vienna);
+
+        when(worldGraph.getCityById("other")).thenReturn(someNode);
+        when(movementEngine.getValidOptions(any(), any(), anyInt(), any()))
+                .thenReturn(List.of(new Connection(viennaNode, ConnectionType.TRAIN)));
+
+        PlayerState player2 = new PlayerState("player-2");
+        player2.setCurrentCity(city("berlin", "Berlin"));
+        player2.setStartCity(city("berlin", "Berlin"));
+
+        GameRoomState state = inTurnState(List.of(player, player2));
+        state.setLastDiceValue(1);
+
+        service.processCommand(state, moveToCityCommand("vienna"));
+
+        assertThat(state.isGameOver()).isTrue();
+
+        ArgumentCaptor<GameOverMessage> captor = ArgumentCaptor.forClass(GameOverMessage.class);
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/game-over"), captor.capture());
+
+        GameOverMessage gameOverMsg = captor.getValue();
+        assertThat(gameOverMsg.getScores()).hasSize(2);
+        assertThat(gameOverMsg.getScores()).extracting(s -> s.getPlayerName()).contains(PLAYER_ID);
+    }
+
+    // ===== Game-over triggered by returning home after all goals already visited =====
+
+    @Test
+    void returnToStartAfterAllGoalsDone_triggersGameOver() {
+        City vienna = city("vienna", "Vienna");
+        City paris = city("paris", "Paris");
+
+        CityNode parisNode = cityNode("paris", "Paris");
+        CityNode viennaNode = cityNode("vienna", "Vienna");
+
+        PlayerState player = playerAt(paris);
+        player.setStartCity(vienna);
+        player.setRemainingSteps(1);
+        player.getOwnedCities().add(paris);
+        player.getVisitedCities().add(paris);
+
+        when(worldGraph.getCityById("paris")).thenReturn(parisNode);
+        when(movementEngine.getValidOptions(any(), any(), anyInt(), any()))
+                .thenReturn(List.of(new Connection(viennaNode, ConnectionType.TRAIN)));
+
+        GameRoomState state = inTurnState(List.of(player));
+        state.setLastDiceValue(1);
+
+        service.processCommand(state, moveToCityCommand("vienna"));
+
+        assertThat(state.isGameOver()).isTrue();
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/game-over"), any(GameOverMessage.class));
+        verify(messagingTemplate, never()).convertAndSend(
+                eq("/topic/goal-reached"), any(GoalReachedMessage.class));
+    }
+
+    @Test
+    void gameOverNotTriggeredWhenNotAllGoalsDone() {
+        City vienna = city("vienna", "Vienna");
+        City paris = city("paris", "Paris");
+        City berlin = city("berlin", "Berlin");
+
+        CityNode parisNode = cityNode("paris", "Paris");
+        CityNode viennaNode = cityNode("vienna", "Vienna");
+
+        PlayerState player = playerAt(paris);
+        player.setStartCity(vienna);
+        player.setRemainingSteps(1);
+        player.getOwnedCities().add(paris);
+        player.getOwnedCities().add(berlin);
+        player.getVisitedCities().add(paris);
+
+        when(worldGraph.getCityById("paris")).thenReturn(parisNode);
+        when(movementEngine.getValidOptions(any(), any(), anyInt(), any()))
+                .thenReturn(List.of(new Connection(viennaNode, ConnectionType.TRAIN)));
+
+        GameRoomState state = inTurnState(List.of(player));
+        state.setLastDiceValue(1);
+
+        service.processCommand(state, moveToCityCommand("vienna"));
+
+        assertThat(state.isGameOver()).isFalse();
+        verify(messagingTemplate, never()).convertAndSend(
+                eq("/topic/game-over"), any(GameOverMessage.class));
+    }
+
+    // ===== Movement blocked after game over =====
+
+    @Test
+    void rollDiceBlockedAfterGameOver() {
+        GameRoomState state = inTurnState(List.of(playerAt(city("vienna", "Vienna"))));
+        state.setGameOver(true);
+
+        assertThatThrownBy(() -> service.processCommand(state,
+                new ClientCommand(CommandType.ROLL_DICE, LOBBY_ID, PLAYER_ID, null, null)))
+                .isInstanceOf(GameException.class)
+                .hasMessageContaining("beendet");
+    }
+
+    @Test
+    void moveToCityBlockedAfterGameOver() {
+        GameRoomState state = inTurnState(List.of(playerAt(city("vienna", "Vienna"))));
+        state.setGameOver(true);
+        state.setLastDiceValue(3);
+
+        assertThatThrownBy(() -> service.processCommand(state, moveToCityCommand("paris")))
+                .isInstanceOf(GameException.class)
+                .hasMessageContaining("beendet");
+    }
+
+    // ===== Score calculation =====
+
+    @Test
+    void calculateScore_allReached() {
+        PlayerState player = new PlayerState(PLAYER_ID);
+        player.getOwnedCities().add(city("paris", "Paris"));
+        player.getOwnedCities().add(city("berlin", "Berlin"));
+        player.getVisitedCities().add(city("paris", "Paris"));
+        player.getVisitedCities().add(city("berlin", "Berlin"));
+
+        assertThat(service.calculateScore(player)).isEqualTo(2);
+    }
+
+    @Test
+    void calculateScore_noneReached() {
+        PlayerState player = new PlayerState(PLAYER_ID);
+        player.getOwnedCities().add(city("paris", "Paris"));
+        player.getOwnedCities().add(city("berlin", "Berlin"));
+
+        assertThat(service.calculateScore(player)).isEqualTo(-2);
+    }
+
+    @Test
+    void calculateScore_halfReached() {
+        PlayerState player = new PlayerState(PLAYER_ID);
+        player.getOwnedCities().add(city("paris", "Paris"));
+        player.getOwnedCities().add(city("berlin", "Berlin"));
+        player.getVisitedCities().add(city("paris", "Paris"));
+
+        assertThat(service.calculateScore(player)).isEqualTo(0);
+    }
+
+    // ===== Helpers =====
+
+    private City city(String id, String name) {
+        return new City(id, name, Continent.EUROPE_AFRICA, CityColor.RED);
+    }
+
+    private CityNode cityNode(String id, String name) {
+        return new CityNode(id, name, Continent.EUROPE_AFRICA, CityColor.RED);
+    }
+
+    private PlayerState playerAt(City city) {
+        PlayerState player = new PlayerState(PLAYER_ID);
+        player.setCurrentCity(city);
+        return player;
+    }
+
+    private ClientCommand moveToCityCommand(String targetCityId) {
+        return new ClientCommand(CommandType.MOVE_TO_CITY, LOBBY_ID, PLAYER_ID, null, null, targetCityId, null);
+    }
+
+    private GameRoomState inTurnState(List<PlayerState> players) {
+        GameRoomState state = new GameRoomState();
+        state.setLobbyId(LOBBY_ID);
+        state.setPlayers(new ArrayList<>(players));
+        state.setPhase(GamePhase.IN_TURN);
+        state.setCurrentPlayerId(PLAYER_ID);
+        return state;
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/LobbyServiceUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/LobbyServiceUnitTest.java
@@ -286,4 +286,109 @@ class LobbyServiceUnitTest {
         assertThat(state.getPlayers().getFirst().getStartCity()).isNotNull();
         assertThat(state.getPlayers().getFirst().getCurrentCity()).isNotNull();
     }
+
+    // ========== RESET LOBBY TESTS ==========
+
+    @Test
+    void resetLobbySetsPhasBackToLobby() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+
+        GameRoomState state = service.resetLobby("lobby-1", "player-1");
+
+        assertThat(state.getPhase()).isEqualTo(GamePhase.LOBBY);
+    }
+
+    @Test
+    void resetLobbyClearsCurrentPlayerAndDice() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+
+        GameRoomState state = service.resetLobby("lobby-1", "player-1");
+
+        assertThat(state.getCurrentPlayerId()).isNull();
+        assertThat(state.getLastDiceValue()).isNull();
+    }
+
+    @Test
+    void resetLobbySetsGameOverToFalse() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+        GameRoomState state = store.get("lobby-1").orElseThrow();
+        state.setGameOver(true);
+
+        service.resetLobby("lobby-1", "player-1");
+
+        assertThat(state.isGameOver()).isFalse();
+    }
+
+    @Test
+    void resetLobbyKeepsAllPlayers() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+
+        GameRoomState state = service.resetLobby("lobby-1", "player-1");
+
+        assertThat(state.getPlayers()).hasSize(2);
+    }
+
+    @Test
+    void resetLobbyClosesCityDataForAllPlayers() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+
+        GameRoomState state = service.resetLobby("lobby-1", "player-1");
+
+        state.getPlayers().forEach(p -> {
+            assertThat(p.getStartCity()).isNull();
+            assertThat(p.getCurrentCity()).isNull();
+            assertThat(p.getOwnedCities()).isEmpty();
+            assertThat(p.getVisitedCities()).isEmpty();
+        });
+    }
+
+    @Test
+    void resetLobbyIncrementsVersion() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+        long versionBefore = store.get("lobby-1").orElseThrow().getVersion();
+
+        service.resetLobby("lobby-1", "player-1");
+
+        assertThat(store.get("lobby-1").orElseThrow().getVersion()).isGreaterThan(versionBefore);
+    }
+
+    @Test
+    void resetLobbyRejectsNonHost() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+
+        assertThatThrownBy(() -> service.resetLobby("lobby-1", "player-2"))
+                .isInstanceOf(GameException.class);
+    }
+
+    @Test
+    void resetLobbyRejectsNonExistentLobby() {
+        assertThatThrownBy(() -> service.resetLobby("non-existent", "player-1"))
+                .isInstanceOf(GameException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void resetLobbyKeepsGameMode() {
+        service.createLobby("lobby-1", "player-1");
+        service.joinLobby("lobby-1", "player-2");
+        service.startGame("lobby-1", 12);
+        var modeBefore = store.get("lobby-1").orElseThrow().getGameMode();
+
+        GameRoomState state = service.resetLobby("lobby-1", "player-1");
+
+        assertThat(state.getGameMode()).isEqualTo(modeBefore);
+    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/messaging/dtos/TurnBasedDtosUnitTest.java
@@ -25,7 +25,8 @@ class TurnBasedDtosUnitTest {
                 CommandType.MOVE_TO_CITY,
                 CommandType.END_TURN,
                 CommandType.LEAVE_LOBBY,
-                CommandType.LOBBY_CLOSED
+                CommandType.LOBBY_CLOSED,
+                CommandType.RESET_LOBBY
         );
     }
 


### PR DESCRIPTION
 Implementierung der Ziel-erreicht- und Spielende-Logik auf dem Server.

  - Ziel-erreicht-Erkennung: Der GameCommandService prüft nach jeder Stadtbewegung, ob ein Spieler eine seiner
  Zielstädte besucht hat. Bei Erfolg wird sofort eine GoalReachedMessage über den neuen WebSocket-Topic
  /topic/goal-reached an alle Clients gesendet.
  - Spielende-Bedingung: Sobald ein Spieler alle seine Zielstädte besucht hat (isVictory), wird das Spiel als beendet
  markiert (state.setGameOver(true)) und eine GameOverMessage mit der finalen Punkteliste aller Spieler über
  /topic/game-over gebroadcastet. Weitere Züge werden danach geblockt (ErrorCode.GAME_OVER).
  - Punkteberechnung: Der Score ergibt sich aus erreichte Städte − noch offene Städte, abgebildet in calculateScore().
  - Lobby zurücksetzen: Neuer RESET_LOBBY-Befehl ermöglicht es, nach Spielende in die Lobby zurückzukehren, ohne die
  Verbindung zu trennen.
  - Neue DTOs: GoalReachedMessage, GameOverMessage, PlayerScore sowie die zentrale Konstanten-Klasse WebSocketTopics.
  - Tests: Unit-Tests für die Ziel- und Spielende-Logik (GoalAndGameOverUnitTest) sowie ergänzende Tests im
  GameCommandServiceUnitTest.
  - Bugfix: previousCityId wird beim Rundenende korrekt auf null zurückgesetzt, sodass die Stadthistorie in der nächsten
   Runde sauber ist.

