### PR TITLE
fix(game-over): score reflects reached cities and broadcast winnerId

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -268,9 +268,7 @@ public class GameCommandService {
     }
 
     int calculateScore(PlayerState player) {
-        int reached = player.getVisitedCities().size();
-        int remaining = player.getOwnedCities().size() - reached;
-        return reached - remaining;
+        return player.getVisitedCities().size();
     }
 
     private void recomputeValidMoveIds(GameRoomState state) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/game/GameCommandService.java
@@ -210,7 +210,7 @@ public class GameCommandService {
 
         if (!state.isGameOver() && gameSessionService.isVictory(player)) {
             state.setGameOver(true);
-            broadcastGameOver(state);
+            broadcastGameOver(state, player.getPlayerId());
         }
 
         if (newRemainingSteps <= 0) {
@@ -259,12 +259,12 @@ public class GameCommandService {
         messagingTemplate.convertAndSend(WebSocketTopics.GOAL_REACHED, message);
     }
 
-    private void broadcastGameOver(GameRoomState state) {
+    private void broadcastGameOver(GameRoomState state, String winnerId) {
         if (messagingTemplate == null) return;
         List<PlayerScore> scores = state.getPlayers().stream()
                 .map(p -> new PlayerScore(p.getPlayerId(), calculateScore(p)))
                 .collect(Collectors.toList());
-        messagingTemplate.convertAndSend(WebSocketTopics.GAME_OVER, new GameOverMessage(scores));
+        messagingTemplate.convertAndSend(WebSocketTopics.GAME_OVER, new GameOverMessage(winnerId, scores));
     }
 
     int calculateScore(PlayerState player) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameOverMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/messaging/dtos/GameOverMessage.java
@@ -10,5 +10,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GameOverMessage {
+    private String winnerId;
     private List<PlayerScore> scores;
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GoalAndGameOverUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GoalAndGameOverUnitTest.java
@@ -290,7 +290,7 @@ class GoalAndGameOverUnitTest {
         player.getOwnedCities().add(city("paris", "Paris"));
         player.getOwnedCities().add(city("berlin", "Berlin"));
 
-        assertThat(service.calculateScore(player)).isEqualTo(-2);
+        assertThat(service.calculateScore(player)).isEqualTo(0);
     }
 
     @Test
@@ -300,7 +300,7 @@ class GoalAndGameOverUnitTest {
         player.getOwnedCities().add(city("berlin", "Berlin"));
         player.getVisitedCities().add(city("paris", "Paris"));
 
-        assertThat(service.calculateScore(player)).isEqualTo(0);
+        assertThat(service.calculateScore(player)).isEqualTo(1);
     }
 
     // ===== Helpers =====

--- a/src/test/java/at/aau/serg/websocketdemoserver/game/GoalAndGameOverUnitTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/game/GoalAndGameOverUnitTest.java
@@ -183,6 +183,7 @@ class GoalAndGameOverUnitTest {
         GameOverMessage gameOverMsg = captor.getValue();
         assertThat(gameOverMsg.getScores()).hasSize(2);
         assertThat(gameOverMsg.getScores()).extracting(s -> s.getPlayerName()).contains(PLAYER_ID);
+        assertThat(gameOverMsg.getWinnerId()).isEqualTo(PLAYER_ID);
     }
 
     // ===== Game-over triggered by returning home after all goals already visited =====


### PR DESCRIPTION
## Summary
  - `calculateScore` gibt jetzt `visitedCities.size()` zurück (Anzahl der erreichten Pflichtziele) statt `reached - remaining`. Damit zeigt das Scoreboard nie negative Werte mehr.
  - `GameOverMessage` bekommt ein neues Feld `winnerId`. Der Spieler, der `isVictory` triggert (alle Ziele + zurück in Startstadt), wird beim `broadcastGameOver` als Sieger mitgeschickt — eindeutig auch bei Score-Gleichstand.